### PR TITLE
fix: StaticCredsExecutor should run as daemon thread for clean shutdown

### DIFF
--- a/core/src/main/java/tech/ydb/core/auth/StaticCredentials.java
+++ b/core/src/main/java/tech/ydb/core/auth/StaticCredentials.java
@@ -21,7 +21,11 @@ import tech.ydb.auth.YdbAuth;
 public class StaticCredentials implements AuthProvider {
     private static final Logger logger = LoggerFactory.getLogger(StaticCredentials.class);
     private static final Supplier<ExecutorService> DEFAULT_EXECUTOR = () -> Executors
-            .newSingleThreadExecutor(r -> new Thread(r, "StaticCredsExecutor"));
+            .newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "StaticCredsExecutor");
+                t.setDaemon(true);
+                return t;
+            });
 
     private final Clock clock;
     private final YdbAuth.LoginRequest request;


### PR DESCRIPTION
When using static credentials, an additional thread is created to for background token updates.
This thread needs to be marked as "daemon", otherwise it prevents the shutdown of an application.