### PR TITLE
Update TtlSettings to TableTtl into the TableDescription

### DIFF
--- a/table/src/main/java/tech/ydb/table/description/TableDescription.java
+++ b/table/src/main/java/tech/ydb/table/description/TableDescription.java
@@ -1,21 +1,14 @@
 package tech.ydb.table.description;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import com.google.common.collect.ImmutableList;
-
+import tech.ydb.table.description.TableTtl.TtlMode;
 import tech.ydb.table.settings.PartitioningSettings;
-import tech.ydb.table.settings.TtlSettings;
 import tech.ydb.table.values.OptionalType;
 import tech.ydb.table.values.Type;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.*;
 
 /**
  * @author Sergey Polovko
@@ -35,8 +28,7 @@ public class TableDescription {
 
     private final List<PartitionStats> partitionStats;
 
-    @Nullable
-    private final TtlSettings ttlSettings;
+    private final TableTtl tableTtl;
 
     private TableDescription(Builder builder) {
         this.primaryKeys = ImmutableList.copyOf(builder.primaryKeys);
@@ -48,7 +40,7 @@ public class TableDescription {
         this.tableStats = builder.tableStats;
         this.partitioningSettings = builder.partitioningSettings;
         this.partitionStats = ImmutableList.copyOf(builder.partitionStats);
-        this.ttlSettings = builder.ttlSettings;
+        this.tableTtl = builder.ttlSettings;
     }
 
     public static Builder newBuilder() {
@@ -89,9 +81,8 @@ public class TableDescription {
         return keyRanges;
     }
 
-    @Nullable
-    public TtlSettings getTtlSettings() {
-        return ttlSettings;
+    public TableTtl getTableTtl() {
+        return tableTtl;
     }
 
     /**
@@ -108,7 +99,7 @@ public class TableDescription {
         private TableStats tableStats = null;
         private PartitioningSettings partitioningSettings = null;
         private final List<PartitionStats> partitionStats = new ArrayList<>();
-        private TtlSettings ttlSettings = null;
+        private TableTtl ttlSettings = new TableTtl();
 
         public Builder addNonnullColumn(String name, Type type) {
             return addNonnullColumn(name, type, null);
@@ -212,8 +203,8 @@ public class TableDescription {
             return this;
         }
 
-        public Builder setTtlSettings(String columnName, int expireAfterSeconds) {
-            this.ttlSettings = new TtlSettings(columnName, expireAfterSeconds);
+        public Builder setTtlSettings(int ttlModeCase, String columnName, int expireAfterSeconds) {
+            this.ttlSettings = new TableTtl(TtlMode.forCase(ttlModeCase), columnName, expireAfterSeconds);
             return this;
         }
 

--- a/table/src/main/java/tech/ydb/table/description/TableDescription.java
+++ b/table/src/main/java/tech/ydb/table/description/TableDescription.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 
 import tech.ydb.table.settings.PartitioningSettings;
+import tech.ydb.table.settings.TtlSettings;
 import tech.ydb.table.values.OptionalType;
 import tech.ydb.table.values.Type;
 
@@ -34,6 +35,9 @@ public class TableDescription {
 
     private final List<PartitionStats> partitionStats;
 
+    @Nullable
+    private final TtlSettings ttlSettings;
+
     private TableDescription(Builder builder) {
         this.primaryKeys = ImmutableList.copyOf(builder.primaryKeys);
         this.columns = builder.buildColumns();
@@ -44,6 +48,7 @@ public class TableDescription {
         this.tableStats = builder.tableStats;
         this.partitioningSettings = builder.partitioningSettings;
         this.partitionStats = ImmutableList.copyOf(builder.partitionStats);
+        this.ttlSettings = builder.ttlSettings;
     }
 
     public static Builder newBuilder() {
@@ -84,6 +89,11 @@ public class TableDescription {
         return keyRanges;
     }
 
+    @Nullable
+    public TtlSettings getTtlSettings() {
+        return ttlSettings;
+    }
+
     /**
      * BUILDER
      */
@@ -98,6 +108,7 @@ public class TableDescription {
         private TableStats tableStats = null;
         private PartitioningSettings partitioningSettings = null;
         private final List<PartitionStats> partitionStats = new ArrayList<>();
+        private TtlSettings ttlSettings = null;
 
         public Builder addNonnullColumn(String name, Type type) {
             return addNonnullColumn(name, type, null);
@@ -198,6 +209,11 @@ public class TableDescription {
 
         public Builder addPartitionStat(long rows, long size) {
             this.partitionStats.add(new PartitionStats(rows, size));
+            return this;
+        }
+
+        public Builder setTtlSettings(String columnName, int expireAfterSeconds) {
+            this.ttlSettings = new TtlSettings(columnName, expireAfterSeconds);
             return this;
         }
 

--- a/table/src/main/java/tech/ydb/table/description/TableTtl.java
+++ b/table/src/main/java/tech/ydb/table/description/TableTtl.java
@@ -1,0 +1,61 @@
+package tech.ydb.table.description;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class TableTtl {
+    @Nonnull
+    private final TtlMode ttlMode;
+    @Nullable
+    private final String dateTimeColumn;
+    @Nullable
+    private final Integer expireAfterSeconds;
+
+    public TableTtl(@Nonnull TtlMode ttlMode, @Nonnull String dateTimeColumn, @Nonnull Integer expireAfterSeconds) {
+        this.ttlMode = ttlMode;
+        this.dateTimeColumn = dateTimeColumn;
+        this.expireAfterSeconds = expireAfterSeconds;
+    }
+
+    public TableTtl() {
+        this.ttlMode = TtlMode.NOT_SET;
+        this.dateTimeColumn = null;
+        this.expireAfterSeconds = null;
+    }
+
+    @Nonnull
+    public TtlMode getTtlMode() {
+        return ttlMode;
+    }
+
+    @Nullable
+    public String getDateTimeColumn() {
+        return dateTimeColumn;
+    }
+
+    @Nullable
+    public Integer getExpireAfterSeconds() {
+        return expireAfterSeconds;
+    }
+
+    public enum TtlMode {
+        DATE_TYPE_COLUMN(1),
+        VALUE_SINCE_UNIX_EPOCH(2),
+        NOT_SET(0);
+
+        private final int caseMapping;
+
+        TtlMode(int caseMapping) {
+            this.caseMapping = caseMapping;
+        }
+
+        public static TtlMode forCase(int value) {
+            for (TtlMode mode: values()) {
+                if (mode.caseMapping == value) {
+                    return mode;
+                }
+            }
+            throw new IllegalArgumentException("No TTL mode defined for specified value");
+        }
+    }
+}

--- a/table/src/main/java/tech/ydb/table/impl/BaseSession.java
+++ b/table/src/main/java/tech/ydb/table/impl/BaseSession.java
@@ -499,6 +499,20 @@ public abstract class BaseSession implements Session {
             }
         }
 
+        YdbTable.TtlSettings ttlSettings = result.getTtlSettings();
+        switch (ttlSettings.getModeCase()) {
+            case DATE_TYPE_COLUMN:
+                YdbTable.DateTypeColumnModeSettings dateTypeColumn = ttlSettings.getDateTypeColumn();
+                description.setTtlSettings(dateTypeColumn.getColumnName(), dateTypeColumn.getExpireAfterSeconds());
+                break;
+            case VALUE_SINCE_UNIX_EPOCH:
+                YdbTable.ValueSinceUnixEpochModeSettings valueSinceUnixEpoch = ttlSettings.getValueSinceUnixEpoch();
+                description.setTtlSettings(valueSinceUnixEpoch.getColumnName(), valueSinceUnixEpoch.getExpireAfterSeconds());
+                break;
+            default:
+                break;
+        }
+
         return description.build();
     }
 

--- a/table/src/main/java/tech/ydb/table/impl/BaseSession.java
+++ b/table/src/main/java/tech/ydb/table/impl/BaseSession.java
@@ -500,14 +500,15 @@ public abstract class BaseSession implements Session {
         }
 
         YdbTable.TtlSettings ttlSettings = result.getTtlSettings();
+        int ttlModeCase = ttlSettings.getModeCase().getNumber();
         switch (ttlSettings.getModeCase()) {
             case DATE_TYPE_COLUMN:
                 YdbTable.DateTypeColumnModeSettings dateTypeColumn = ttlSettings.getDateTypeColumn();
-                description.setTtlSettings(dateTypeColumn.getColumnName(), dateTypeColumn.getExpireAfterSeconds());
+                description.setTtlSettings(ttlModeCase, dateTypeColumn.getColumnName(), dateTypeColumn.getExpireAfterSeconds());
                 break;
             case VALUE_SINCE_UNIX_EPOCH:
                 YdbTable.ValueSinceUnixEpochModeSettings valueSinceUnixEpoch = ttlSettings.getValueSinceUnixEpoch();
-                description.setTtlSettings(valueSinceUnixEpoch.getColumnName(), valueSinceUnixEpoch.getExpireAfterSeconds());
+                description.setTtlSettings(ttlModeCase, valueSinceUnixEpoch.getColumnName(), valueSinceUnixEpoch.getExpireAfterSeconds());
                 break;
             default:
                 break;

--- a/table/src/test/java/tech/ydb/table/utils/TtlModeMappingTest.java
+++ b/table/src/test/java/tech/ydb/table/utils/TtlModeMappingTest.java
@@ -1,0 +1,17 @@
+package tech.ydb.table.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import tech.ydb.table.YdbTable;
+import tech.ydb.table.description.TableTtl;
+
+public class TtlModeMappingTest {
+    @Test
+    public void protoMappingTest() {
+        YdbTable.TtlSettings.ModeCase[] apiValues = YdbTable.TtlSettings.ModeCase.values();
+        for (YdbTable.TtlSettings.ModeCase apiValue : apiValues) {
+            TableTtl.TtlMode sdkTtlMode = TableTtl.TtlMode.forCase(apiValue.getNumber());
+            Assert.assertNotNull(String.format("TtlMode not defined for %s", apiValue), sdkTtlMode);
+        }
+    }
+}


### PR DESCRIPTION
**Reasoning :**
Right now it is difficult to set up TTL for tables automatically using SDK because there is no way to get current TTL settings of the table due to current structure of the TableDescription class.
**Solution :**
This PR adds in mapping for TtlSettings response of the describe table request and saves it into the TableDescription