### PR TITLE
Rewrite all asynchronous tasks to use single scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.0 ##
 
+* All periodic tasks have been moved to unite scheduled executor service
 * Added support of integration tests for JUnit4 and JUnit5
 * Added bom module to simplify the import of SDK and its dependencies
 * SchemeClient has been moved to its own module

--- a/core/src/main/java/tech/ydb/core/grpc/GrpcTransport.java
+++ b/core/src/main/java/tech/ydb/core/grpc/GrpcTransport.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
@@ -22,6 +23,8 @@ import tech.ydb.core.utils.URITools;
  * @author Nikolay Perfilov
  */
 public interface GrpcTransport extends AutoCloseable {
+
+    ScheduledExecutorService scheduler();
 
     String getEndpointByNodeId(int nodeId);
 

--- a/core/src/main/java/tech/ydb/core/grpc/impl/GrpcAuthRpc.java
+++ b/core/src/main/java/tech/ydb/core/grpc/impl/GrpcAuthRpc.java
@@ -31,6 +31,7 @@ public class GrpcAuthRpc {
         // For auth provider we use transport without auth (with default CallOptions)
         return new SingleChannelTransport(
                 CallOptions.DEFAULT,
+                parent.scheduler(),
                 parent.getDefaultReadTimeoutMillis(),
                 parent.getDatabase(),
                 endpoint,

--- a/core/src/main/java/tech/ydb/core/grpc/impl/GrpcAuthRpc.java
+++ b/core/src/main/java/tech/ydb/core/grpc/impl/GrpcAuthRpc.java
@@ -1,5 +1,7 @@
 package tech.ydb.core.grpc.impl;
 
+import java.util.concurrent.ExecutorService;
+
 import io.grpc.CallOptions;
 
 import tech.ydb.core.grpc.GrpcTransport;
@@ -17,6 +19,10 @@ public class GrpcAuthRpc {
         this.endpoint = endpoint;
         this.parent = parent;
         this.channelFactory = channelFactory;
+    }
+
+    public ExecutorService getExecutor() {
+        return parent.scheduler();
     }
 
     public String getEndpoint() {

--- a/core/src/main/java/tech/ydb/core/grpc/impl/GrpcDiscoveryRpc.java
+++ b/core/src/main/java/tech/ydb/core/grpc/impl/GrpcDiscoveryRpc.java
@@ -58,6 +58,7 @@ public class GrpcDiscoveryRpc {
     private GrpcTransport createTransport() {
         return new SingleChannelTransport(
                 parent.getCallOptions(),
+                parent.scheduler(),
                 parent.getDefaultReadTimeoutMillis(),
                 parent.getDatabase(),
                 endpoint,

--- a/core/src/main/java/tech/ydb/core/grpc/impl/SingleChannelTransport.java
+++ b/core/src/main/java/tech/ydb/core/grpc/impl/SingleChannelTransport.java
@@ -1,5 +1,7 @@
 package tech.ydb.core.grpc.impl;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.Status;
@@ -16,19 +18,27 @@ public class SingleChannelTransport extends BaseGrpcTrasnsport {
     private static final Logger logger = LoggerFactory.getLogger(SingleChannelTransport.class);
 
     private final CallOptions callOptions;
+    private final ScheduledExecutorService scheduler;
     private final String database;
     private final GrpcChannel channel;
 
     public SingleChannelTransport(
             CallOptions callOptions,
+            ScheduledExecutorService scheduler,
             long readTimeoutMillis,
             String database,
             EndpointRecord endpoint,
             ChannelFactory channelFactory) {
         super(readTimeoutMillis);
         this.callOptions = callOptions;
+        this.scheduler = scheduler;
         this.database = database;
         this.channel = new GrpcChannel(endpoint, channelFactory, true);
+    }
+
+    @Override
+    public ScheduledExecutorService scheduler() {
+        return scheduler;
     }
 
     @Override

--- a/core/src/main/java/tech/ydb/core/grpc/impl/YdbSchedulerThreadFactory.java
+++ b/core/src/main/java/tech/ydb/core/grpc/impl/YdbSchedulerThreadFactory.java
@@ -1,0 +1,28 @@
+package tech.ydb.core.grpc.impl;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *
+ * @author Aleksandr Gorshenin
+ */
+class YdbSchedulerThreadFactory implements ThreadFactory {
+    private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger(1);
+
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+    private final String namePrefix;
+
+    YdbSchedulerThreadFactory() {
+        namePrefix = "ydb-scheduler-" +
+                      INSTANCE_COUNT.getAndIncrement() +
+                     "-thread-";
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(r, namePrefix + threadNumber.getAndIncrement());
+        t.setDaemon(true);
+        return t;
+    }
+}

--- a/core/src/main/java/tech/ydb/core/grpc/impl/YdbTransportImpl.java
+++ b/core/src/main/java/tech/ydb/core/grpc/impl/YdbTransportImpl.java
@@ -74,7 +74,7 @@ public class YdbTransportImpl extends BaseGrpcTrasnsport {
         this.channelPool = new GrpcChannelPool(channelFactory);
         this.endpointPool = new EndpointPool(balancingSettings);
         this.discoveryHandler = new YdbDiscoveryHandler();
-        this.periodicDiscoveryTask = new PeriodicDiscoveryTask(discoveryRpc, discoveryHandler);
+        this.periodicDiscoveryTask = new PeriodicDiscoveryTask(scheduler, discoveryRpc, discoveryHandler);
     }
 
     public void init() {

--- a/core/src/main/java/tech/ydb/core/grpc/impl/YdbTransportImpl.java
+++ b/core/src/main/java/tech/ydb/core/grpc/impl/YdbTransportImpl.java
@@ -4,6 +4,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Strings;
 import com.google.common.net.HostAndPort;
@@ -30,6 +33,7 @@ import tech.ydb.discovery.DiscoveryProtos;
  */
 public class YdbTransportImpl extends BaseGrpcTrasnsport {
     private static final int DEFAULT_PORT = 2135;
+    private static final long WAIT_FOR_SHUTDOWN_MS = 1000;
 
     private static final Result<?> SHUTDOWN_RESULT =  Result.fail(tech.ydb.core.Status.of(
             StatusCode.CLIENT_CANCELLED, null,
@@ -45,6 +49,8 @@ public class YdbTransportImpl extends BaseGrpcTrasnsport {
     private final GrpcChannelPool channelPool;
     private final YdbDiscoveryHandler discoveryHandler;
     private final PeriodicDiscoveryTask periodicDiscoveryTask;
+    private final ScheduledExecutorService scheduler;
+
     private volatile boolean shutdown = false;
 
     public YdbTransportImpl(GrpcTransportBuilder builder) {
@@ -63,6 +69,7 @@ public class YdbTransportImpl extends BaseGrpcTrasnsport {
                 builder.getCallExecutor()
         );
         this.discoveryRpc = new GrpcDiscoveryRpc(this, discoveryEndpoint, channelFactory);
+        this.scheduler = Executors.newScheduledThreadPool(1, new YdbSchedulerThreadFactory());
 
         this.channelPool = new GrpcChannelPool(channelFactory);
         this.endpointPool = new EndpointPool(balancingSettings);
@@ -116,6 +123,11 @@ public class YdbTransportImpl extends BaseGrpcTrasnsport {
     }
 
     @Override
+    public ScheduledExecutorService scheduler() {
+        return scheduler;
+    }
+
+    @Override
     public String getEndpointByNodeId(int nodeId) {
         return endpointPool.getEndpointByNodeId(nodeId);
     }
@@ -152,7 +164,31 @@ public class YdbTransportImpl extends BaseGrpcTrasnsport {
         periodicDiscoveryTask.stop();
         channelPool.shutdown();
         callOptionsProvider.close();
+
+        shutdownScheduler();
     }
+
+    private boolean shutdownScheduler() {
+        try {
+            scheduler.shutdown();
+            boolean closed = scheduler.awaitTermination(WAIT_FOR_SHUTDOWN_MS, TimeUnit.MILLISECONDS);
+            if (!closed) {
+                logger.warn("ydb scheduler shutdown timeout exceeded, terminate");
+                scheduler.shutdownNow();
+                closed = scheduler.awaitTermination(WAIT_FOR_SHUTDOWN_MS, TimeUnit.MILLISECONDS);
+                if (!closed) {
+                    logger.warn("ydb scheduler shutdown problem");
+                }
+            }
+
+            return closed;
+        } catch (InterruptedException e) {
+            logger.warn("ydb scheduler shutdown interrupted {}", e);
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
 
     @Override
     public String getDatabase() {

--- a/core/src/main/java/tech/ydb/core/utils/Async.java
+++ b/core/src/main/java/tech/ydb/core/utils/Async.java
@@ -62,6 +62,7 @@ public class Async {
         }
     }
 
+    @Deprecated
     public static Timeout runAfter(TimerTask task, long delay, TimeUnit unit) {
         return DEFAULT_TIMER.newTimeout(task, delay, unit);
     }

--- a/core/src/test/java/tech/ydb/core/auth/CredentialsAuthProviderTest.java
+++ b/core/src/test/java/tech/ydb/core/auth/CredentialsAuthProviderTest.java
@@ -41,6 +41,7 @@ public class CredentialsAuthProviderTest {
         Mockito.when(rpc.getEndpoint()).thenReturn("Mocked endpoint");
         Mockito.when(rpc.getDatabase()).thenReturn("Mocked database name");
         Mockito.when(rpc.createTransport()).thenReturn(transport);
+        Mockito.when(rpc.getExecutor()).thenReturn(MoreExecutors.newDirectExecutorService());
     }
 
     @Test
@@ -208,8 +209,7 @@ public class CredentialsAuthProviderTest {
     }
 
     private tech.ydb.auth.AuthIdentity createAuth(String login, String password) {
-        return new StaticCredentials(clock, login, password,
-                () -> MoreExecutors.newDirectExecutorService())
+        return new StaticCredentials(clock, login, password)
                 .createAuthIdentity(rpc);
     }
 

--- a/table/src/main/java/tech/ydb/table/SessionRetryContext.java
+++ b/table/src/main/java/tech/ydb/table/SessionRetryContext.java
@@ -9,15 +9,12 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.common.util.concurrent.MoreExecutors;
-import io.grpc.netty.shaded.io.netty.util.Timeout;
-import io.grpc.netty.shaded.io.netty.util.TimerTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,13 +73,13 @@ public class SessionRetryContext {
 
     public <T> CompletableFuture<Result<T>> supplyResult(Function<Session, CompletableFuture<Result<T>>> fn) {
         RetryableResultTask<T> task = new RetryableResultTask<>(fn);
-        task.run();
+        task.requestSession();
         return task.getFuture();
     }
 
     public CompletableFuture<Status> supplyStatus(Function<Session, CompletableFuture<Status>> fn) {
         RetryableStatusTask task = new RetryableStatusTask(fn);
-        task.run();
+        task.requestSession();
         return task.getFuture();
     }
 
@@ -174,7 +171,7 @@ public class SessionRetryContext {
     /**
      * BASE RETRYABLE TASK
      */
-    private abstract class BaseRetryableTask<R> implements TimerTask, BiConsumer<Result<Session>, Throwable> {
+    private abstract class BaseRetryableTask<R> implements Runnable {
         private final CompletableFuture<R> promise = new CompletableFuture<>();
         private final AtomicInteger retryNumber = new AtomicInteger();
         private final Function<Session, CompletableFuture<R>> fn;
@@ -197,35 +194,32 @@ public class SessionRetryContext {
 
         // called on timer expiration
         @Override
-        public void run(Timeout timeout) {
+        public void run() {
             if (promise.isCancelled()) {
                 logger.debug("RetryCtx[{}] cancelled, {} retries, {} ms", hashCode(), retryNumber.get(), ms());
                 return;
             }
-            // call run() method outside of the timer thread
-            executor.execute(this::run);
+            executor.execute(this::requestSession);
         }
 
-        public void run() {
+        public void requestSession() {
             CompletableFuture<Result<Session>> sessionFuture = sessionSupplier.createSession(sessionCreationTimeout);
             if (sessionFuture.isDone() && !sessionFuture.isCompletedExceptionally()) {
                 // faster than subscribing on future
-                accept(sessionFuture.getNow(null), null);
+                acceptSession(sessionFuture.join());
             } else {
-                sessionFuture.whenCompleteAsync(this, executor);
+                sessionFuture.whenCompleteAsync((result, th) -> {
+                    if (result != null) {
+                        acceptSession(result);
+                    }
+                    if (th != null) {
+                        handleException(th);
+                    }
+                }, executor);
             }
         }
 
-        // called on session acquiring
-        @Override
-        public void accept(Result<Session> sessionResult, Throwable sessionException) {
-            assert (sessionResult == null) != (sessionException == null);
-
-            if (sessionException != null) {
-                handleException(sessionException);
-                return;
-            }
-
+        private void acceptSession(@Nonnull Result<Session> sessionResult) {
             if (!sessionResult.isSuccess()) {
                 handleError(sessionResult.getStatus().getCode(), toFailedResult(sessionResult));
                 return;
@@ -262,7 +256,7 @@ public class SessionRetryContext {
             if (promise.isCancelled()) {
                 return;
             }
-            Async.runAfter(this, delayMillis, TimeUnit.MILLISECONDS);
+            sessionSupplier.scheduler().schedule(this, delayMillis, TimeUnit.MILLISECONDS);
         }
 
         private void handleError(@Nonnull StatusCode code, R result) {

--- a/table/src/main/java/tech/ydb/table/SessionSupplier.java
+++ b/table/src/main/java/tech/ydb/table/SessionSupplier.java
@@ -2,6 +2,7 @@ package tech.ydb.table;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import tech.ydb.core.Result;
 
@@ -18,5 +19,11 @@ public interface SessionSupplier {
      * Result when session created, and fail Result otherwise
      */
     CompletableFuture<Result<Session>> createSession(Duration duration);
+
+    /**
+     * Default scheduler for asynchronous tasks execution
+     * @return Default tasks scheduler
+     */
+    ScheduledExecutorService scheduler();
 
 }

--- a/table/src/main/java/tech/ydb/table/impl/PooledTableClient.java
+++ b/table/src/main/java/tech/ydb/table/impl/PooledTableClient.java
@@ -3,6 +3,7 @@ package tech.ydb.table.impl;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.base.Preconditions;
@@ -29,9 +30,11 @@ public class PooledTableClient implements TableClient {
             Issue.of("Timeout of getting session from pool", Issue.Severity.WARNING)
     );
 
+    private final TableRpc tableRpc;
     private final SessionPool pool;
 
     PooledTableClient(Builder builder) {
+        this.tableRpc = builder.tableRpc;
         this.pool = new SessionPool(
                 Clock.systemUTC(),
                 builder.tableRpc,
@@ -55,6 +58,11 @@ public class PooledTableClient implements TableClient {
             }
             return Result.success(session);
         });
+    }
+
+    @Override
+    public ScheduledExecutorService scheduler() {
+        return tableRpc.scheduler();
     }
 
     @Override

--- a/table/src/main/java/tech/ydb/table/impl/PooledTableClient.java
+++ b/table/src/main/java/tech/ydb/table/impl/PooledTableClient.java
@@ -3,8 +3,6 @@ package tech.ydb.table.impl;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.base.Preconditions;
@@ -31,14 +29,10 @@ public class PooledTableClient implements TableClient {
             Issue.of("Timeout of getting session from pool", Issue.Severity.WARNING)
     );
 
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
-            (Runnable r) -> new Thread(r, "YdbTablePoolScheduler")
-    );
     private final SessionPool pool;
 
     PooledTableClient(Builder builder) {
         this.pool = new SessionPool(
-                executor,
                 Clock.systemUTC(),
                 builder.tableRpc,
                 builder.keepQueryText,
@@ -66,7 +60,6 @@ public class PooledTableClient implements TableClient {
     @Override
     public void close() {
         pool.close();
-        executor.shutdown();
     }
 
     @Override

--- a/table/src/main/java/tech/ydb/table/impl/SimpleTableClient.java
+++ b/table/src/main/java/tech/ydb/table/impl/SimpleTableClient.java
@@ -2,6 +2,7 @@ package tech.ydb.table.impl;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import tech.ydb.core.Result;
 import tech.ydb.core.StatusCode;
@@ -30,6 +31,11 @@ public class SimpleTableClient implements SessionSupplier {
                 .setTimeout(duration);
         return BaseSession.createSessionId(tableRpc, settings, false)
                 .thenApply(response -> response.map(SimpleSession::new));
+    }
+
+    @Override
+    public ScheduledExecutorService scheduler() {
+        return tableRpc.scheduler();
     }
 
     public static Builder newClient(TableRpc rpc) {

--- a/table/src/main/java/tech/ydb/table/impl/pool/SessionPool.java
+++ b/table/src/main/java/tech/ydb/table/impl/pool/SessionPool.java
@@ -35,12 +35,11 @@ public class SessionPool implements AutoCloseable {
     private final WaitingQueue<ClosableSession> queue;
     private final ScheduledFuture<?> keepAliveFuture;
 
-    public SessionPool(ScheduledExecutorService scheduler, Clock clock,
-            TableRpc rpc, boolean keepQueryText, SessionPoolOptions options) {
+    public SessionPool(Clock clock, TableRpc rpc, boolean keepQueryText, SessionPoolOptions options) {
         this.minSize = options.getMinSize();
 
         this.clock = clock;
-        this.scheduler = scheduler;
+        this.scheduler = rpc.getScheduler();
         this.queue = new WaitingQueue<>(new Handler(rpc, keepQueryText), options.getMaxSize());
 
         KeepAliveTask keepAlive = new KeepAliveTask(options);

--- a/table/src/main/java/tech/ydb/table/impl/pool/SessionPool.java
+++ b/table/src/main/java/tech/ydb/table/impl/pool/SessionPool.java
@@ -39,7 +39,7 @@ public class SessionPool implements AutoCloseable {
         this.minSize = options.getMinSize();
 
         this.clock = clock;
-        this.scheduler = rpc.getScheduler();
+        this.scheduler = rpc.scheduler();
         this.queue = new WaitingQueue<>(new Handler(rpc, keepQueryText), options.getMaxSize());
 
         KeepAliveTask keepAlive = new KeepAliveTask(options);

--- a/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
+++ b/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
@@ -1,6 +1,7 @@
 package tech.ydb.table.rpc;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.Nullable;
 
@@ -53,6 +54,8 @@ public interface TableRpc extends Rpc {
      */
     @Nullable
     EndpointInfo getEndpointBySessionId(String sessionId);
+
+    ScheduledExecutorService getScheduler();
 
     /**
      * Create new session. Implicit session creation is forbidden, so user must create new session

--- a/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
+++ b/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
@@ -55,7 +55,7 @@ public interface TableRpc extends Rpc {
     @Nullable
     EndpointInfo getEndpointBySessionId(String sessionId);
 
-    ScheduledExecutorService getScheduler();
+    ScheduledExecutorService scheduler();
 
     /**
      * Create new session. Implicit session creation is forbidden, so user must create new session

--- a/table/src/main/java/tech/ydb/table/rpc/grpc/GrpcTableRpc.java
+++ b/table/src/main/java/tech/ydb/table/rpc/grpc/GrpcTableRpc.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -241,6 +242,11 @@ public final class GrpcTableRpc implements TableRpc {
     @Override
     public String getDatabase() {
         return transport.getDatabase();
+    }
+
+    @Override
+    public ScheduledExecutorService getScheduler() {
+        return transport.scheduler();
     }
 
     @Override

--- a/table/src/main/java/tech/ydb/table/rpc/grpc/GrpcTableRpc.java
+++ b/table/src/main/java/tech/ydb/table/rpc/grpc/GrpcTableRpc.java
@@ -245,7 +245,7 @@ public final class GrpcTableRpc implements TableRpc {
     }
 
     @Override
-    public ScheduledExecutorService getScheduler() {
+    public ScheduledExecutorService scheduler() {
         return transport.scheduler();
     }
 

--- a/table/src/test/java/tech/ydb/table/SessionRetryContextTest.java
+++ b/table/src/test/java/tech/ydb/table/SessionRetryContextTest.java
@@ -494,6 +494,11 @@ public class SessionRetryContextTest extends FutureHelper  {
         public CompletableFuture<Result<Session>> createSession(Duration timeout) {
             return completedFuture(Result.success(new SessionStub()));
         }
+
+        @Override
+        public ScheduledExecutorService scheduler() {
+            return scheduler;
+        }
     }
 
     /**
@@ -507,6 +512,11 @@ public class SessionRetryContextTest extends FutureHelper  {
         FailSupplier(int maxFails, StatusCode statusCode) {
             this.maxFails = maxFails;
             this.statusCode = statusCode;
+        }
+
+        @Override
+        public ScheduledExecutorService scheduler() {
+            return scheduler;
         }
 
         int getRequestsCount() {
@@ -530,6 +540,11 @@ public class SessionRetryContextTest extends FutureHelper  {
 
         int getRetriesCount() {
             return retriesCount.get();
+        }
+
+        @Override
+        public ScheduledExecutorService scheduler() {
+            return scheduler;
         }
 
         @Override

--- a/table/src/test/java/tech/ydb/table/SessionRetryContextTest.java
+++ b/table/src/test/java/tech/ydb/table/SessionRetryContextTest.java
@@ -8,8 +8,10 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,6 +44,13 @@ public class SessionRetryContextTest extends FutureHelper  {
     private static final Duration TEN_MILLIS = Duration.ofMillis(10);
     private static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
     private static final Duration TEN_SECONDS = Duration.ofSeconds(10);
+
+    private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    @AfterClass
+    public static void cleanUp() {
+        scheduler.shutdown();
+    }
 
     @Test
     public void successSession_successResult() {
@@ -396,7 +405,7 @@ public class SessionRetryContextTest extends FutureHelper  {
 
     @Test
     public void baseUsageTest() throws InterruptedException {
-        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC());
+        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC(), scheduler);
         TableClient client = PooledTableClient.newClient(rpc).sessionPoolSize(0, 2).build();
 
         SessionRetryContext ctx = SessionRetryContext.create(client)
@@ -436,7 +445,7 @@ public class SessionRetryContextTest extends FutureHelper  {
     @Test
     public void customExecutorUsageTest() throws InterruptedException {
         ExecutorService custom = Executors.newSingleThreadExecutor();
-        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC());
+        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC(), scheduler);
         TableClient client = PooledTableClient.newClient(rpc).sessionPoolSize(0, 2).build();
 
         SessionRetryContext ctx = SessionRetryContext.create(client)

--- a/table/src/test/java/tech/ydb/table/TableRpcStub.java
+++ b/table/src/test/java/tech/ydb/table/TableRpcStub.java
@@ -168,7 +168,7 @@ public class TableRpcStub implements TableRpc {
     }
 
     @Override
-    public ScheduledExecutorService getScheduler() {
+    public ScheduledExecutorService scheduler() {
         return scheduler;
     }
 

--- a/table/src/test/java/tech/ydb/table/TableRpcStub.java
+++ b/table/src/test/java/tech/ydb/table/TableRpcStub.java
@@ -1,6 +1,7 @@
 package tech.ydb.table;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import tech.ydb.core.Issue;
 import tech.ydb.core.Result;
@@ -43,6 +44,12 @@ import static tech.ydb.table.YdbTable.RollbackTransactionRequest;
  * @author Sergey Polovko
  */
 public class TableRpcStub implements TableRpc {
+    private final ScheduledExecutorService scheduler;
+
+    public TableRpcStub(ScheduledExecutorService scheduler) {
+        this.scheduler = scheduler;
+    }
+
     @Override
     public CompletableFuture<Result<CreateSessionResult>> createSession(CreateSessionRequest request,
                                                                           GrpcRequestSettings settings) {
@@ -158,6 +165,11 @@ public class TableRpcStub implements TableRpc {
     @Override
     public String getDatabase() {
         return "";
+    }
+
+    @Override
+    public ScheduledExecutorService getScheduler() {
+        return scheduler;
     }
 
     @Override

--- a/table/src/test/java/tech/ydb/table/impl/PooledTableClientTest.java
+++ b/table/src/test/java/tech/ydb/table/impl/PooledTableClientTest.java
@@ -3,7 +3,10 @@ package tech.ydb.table.impl;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
@@ -22,6 +25,13 @@ import tech.ydb.table.impl.pool.MockedTableRpc;
  * @author Aleksandr Gorshenin
  */
 public class PooledTableClientTest {
+    private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    @AfterClass
+    public static void cleanUp() {
+        scheduler.shutdown();
+    }
+
     private void testAssert(String exceptionMsg, ThrowingRunnable runnable) {
         IllegalArgumentException ex = Assert.assertThrows(
                 "IllegalArgumentException must be throwed",
@@ -192,7 +202,7 @@ public class PooledTableClientTest {
 
     @Test
     public void createSessionTimeout() throws InterruptedException {
-        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC());
+        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC(), scheduler);
         TableClient client = PooledTableClient.newClient(rpc).build();
 
         CompletableFuture<Result<Session>> f1 = client.createSession(Duration.ofMillis(50));
@@ -211,7 +221,7 @@ public class PooledTableClientTest {
 
     @Test
     public void createSessionException() throws InterruptedException {
-        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC());
+        MockedTableRpc rpc = new MockedTableRpc(Clock.systemUTC(), scheduler);
         TableClient client = PooledTableClient.newClient(rpc).build();
 
         CompletableFuture<Result<Session>> f1 = client.createSession(Duration.ofMillis(50));
@@ -265,7 +275,7 @@ public class PooledTableClientTest {
 
     private class DumpTableRpc extends MockedTableRpc {
         public DumpTableRpc() {
-            super(Clock.systemUTC());
+            super(Clock.systemUTC(), scheduler);
         }
 
         @Override
@@ -279,7 +289,7 @@ public class PooledTableClientTest {
 
     private class UnavailableTableRpc extends MockedTableRpc {
         public UnavailableTableRpc() {
-            super(Clock.systemUTC());
+            super(Clock.systemUTC(), scheduler);
         }
 
         @Override

--- a/table/src/test/java/tech/ydb/table/impl/SimpleTableClientTest.java
+++ b/table/src/test/java/tech/ydb/table/impl/SimpleTableClientTest.java
@@ -24,11 +24,12 @@ import org.junit.Test;
  * @author Sergey Polovko
  */
 public class SimpleTableClientTest {
+
     @Test
     public void createSessionAndRelease() throws InterruptedException, ExecutionException {
         Set<String> sessionIDs = new HashSet<>();
 
-        TableRpc fakeRpc = new TableRpcStub() {
+        TableRpc fakeRpc = new TableRpcStub(null) {
             private int counter = 0;
 
             @Override
@@ -77,7 +78,7 @@ public class SimpleTableClientTest {
 
     @Test
     public void unavailableSessions() {
-        TableRpc fakeRpc = new TableRpcStub() {
+        TableRpc fakeRpc = new TableRpcStub(null) {
             @Override
             public CompletableFuture<Result<YdbTable.CreateSessionResult>> createSession(
                 YdbTable.CreateSessionRequest request, GrpcRequestSettings settings) {

--- a/table/src/test/java/tech/ydb/table/impl/pool/MockedTableRpc.java
+++ b/table/src/test/java/tech/ydb/table/impl/pool/MockedTableRpc.java
@@ -7,6 +7,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.grpc.Metadata;
@@ -39,7 +40,8 @@ public class MockedTableRpc extends TableRpcStub {
     private final Queue<KeepAlive> keepAliveQueue = new LinkedBlockingQueue<>();
     private final Queue<DeleteSession> deleteSessionQueue = new LinkedBlockingQueue<>();
 
-    public MockedTableRpc(Clock clock) {
+    public MockedTableRpc(Clock clock, ScheduledExecutorService scheduler) {
+        super(scheduler);
         this.clock = clock;
     }
 

--- a/table/src/test/java/tech/ydb/table/impl/pool/SessionPoolTest.java
+++ b/table/src/test/java/tech/ydb/table/impl/pool/SessionPoolTest.java
@@ -30,7 +30,7 @@ public class SessionPoolTest extends FutureHelper {
 
     private final MockedClock clock = MockedClock.create(ZoneId.of("UTC"));
     private final MockedScheduler scheduler = new MockedScheduler(clock);
-    private final MockedTableRpc tableRpc = new MockedTableRpc(clock);
+    private final MockedTableRpc tableRpc = new MockedTableRpc(clock, scheduler);
 
     @Before
     public void setup() {
@@ -52,7 +52,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void baseTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 2));
 
         check(pool).idle(0).acquired(0).pending(0).size(0, 2);
@@ -90,7 +90,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void createSessionWithErrorTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 3));
 
         check(pool).idle(0).acquired(0).pending(0);
@@ -118,7 +118,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void createSessionShutdownHintTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 3));
 
         check(pool).idle(0).acquired(0).pending(0);
@@ -180,7 +180,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void sessionUseAfterClosingTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 2));
 
         check(pool).idle(0).acquired(0).pending(0);
@@ -253,7 +253,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void createSessionTimeoutTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 2));
 
         check(pool).idle(0).acquired(0).pending(0);
@@ -280,7 +280,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void canceledSessionsTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 2));
 
         check(pool).idle(0).acquired(0).pending(0);
@@ -310,7 +310,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void sessionDataQueryErrorsTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 2));
         check(pool).idle(0).acquired(0).pending(0);
 
@@ -356,7 +356,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void sessionDeleteErrorsTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT.withSize(0, 2));
 
         // Create session1 request
@@ -407,7 +407,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void removeIdleSessionsTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT
                         .withSize(2, 5)
                         .withKeepAliveTimeMillis(5000)
@@ -495,7 +495,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void keepAliveSessionsTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT
                         .withSize(2, 3)
                         .withKeepAliveTimeMillis(1000)
@@ -579,7 +579,7 @@ public class SessionPoolTest extends FutureHelper {
 
     @Test
     public void wrongKeepAliveSessionsTest() {
-        SessionPool pool = new SessionPool(scheduler, clock, tableRpc, true,
+        SessionPool pool = new SessionPool(clock, tableRpc, true,
                 SessionPoolOptions.DEFAULT
                         .withSize(2, 3)
                         .withKeepAliveTimeMillis(1000)

--- a/tests/common/src/main/java/tech/ydb/test/integration/utils/ProxyGrpcTransport.java
+++ b/tests/common/src/main/java/tech/ydb/test/integration/utils/ProxyGrpcTransport.java
@@ -1,6 +1,7 @@
 package tech.ydb.test.integration.utils;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import io.grpc.MethodDescriptor;
 
@@ -29,6 +30,11 @@ public abstract class ProxyGrpcTransport implements GrpcTransport {
     @Override
     public String getEndpointByNodeId(int nodeId) {
         return checked().getEndpointByNodeId(nodeId);
+    }
+
+    @Override
+    public ScheduledExecutorService scheduler() {
+        return checked().scheduler();
     }
 
     @Override


### PR DESCRIPTION
This patch replaces several inner usages of scheduling by single instance of ScheduledExecutorService, defined in GrpcTransport