### PR TITLE
fixing issue #43 on jdk17

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -65,6 +65,18 @@
             <artifactId>truth-proto-extension</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.72</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.72</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Added test scope dependency for org.bouncycastle libraries to enable builds on recent JDK versions