### PR TITLE
Fix/fix topic writer problems

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -389,14 +389,20 @@ public abstract class WriterImpl {
                         }
                         if (sentMessage.getSeqNo() < ack.getSeqNo()) {
                             // An older message hasn't received an Ack while a newer message has
+                            logger.warn("Received an ack for seqNo {}, but the oldest seqNo waiting for ack is {}",
+                                    ack.getSeqNo(), sentMessage.getSeqNo());
                             sentMessage.getFuture().completeExceptionally(
                                     new RuntimeException("Didn't get ack from server for this message"));
                             inFlightFreed++;
                             bytesFreed += sentMessage.getSizeBytes();
                             sentMessages.remove();
+                            // Checking next message waiting for ack
+                        } else {
+                            logger.info("Received an ack with seqNo {} which is older than the oldest message with " +
+                                            "seqNo {} waiting for ack",
+                                    ack.getSeqNo(), sentMessage.getSeqNo());
                             break;
                         }
-                        // Received an ack for a message older than the oldest message waiting for Ack. Ignoring
                     }
                 }
             }

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -185,9 +185,14 @@ public abstract class WriterImpl {
             }
             // This code can be run in one thread at a time due to acquiring writeRequestInProgress
             messages = new LinkedList<>(sendingQueue);
-            sendingQueue.removeAll(messages);
-            sentMessages.addAll(messages);
-            sendMessages(messages);
+            // Checking second time under writeRequestInProgress "lock"
+            if (messages.isEmpty()) {
+                logger.debug("Nothing to send -- sendingQueue is empty #2");
+            } else {
+                sendingQueue.removeAll(messages);
+                sentMessages.addAll(messages);
+                sendMessages(messages);
+            }
             if (!writeRequestInProgress.compareAndSet(true, false)) {
                 logger.error("Couldn't turn off writeRequestInProgress. Should not happen");
             }

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -117,8 +117,8 @@ public abstract class WriterImpl {
         this.lastAcceptedMessageFuture = message.getFuture();
         this.currentInFlightCount++;
         this.availableSizeBytes -= message.getUncompressedSizeBytes();
-        if (logger.isDebugEnabled()) {
-            logger.debug("Accepted 1 message of {} uncompressed bytes. Current In-flight: {}, AvailableSizeBytes: {}",
+        if (logger.isTraceEnabled()) {
+            logger.trace("Accepted 1 message of {} uncompressed bytes. Current In-flight: {}, AvailableSizeBytes: {}",
                     message.getUncompressedSizeBytes(), currentInFlightCount, availableSizeBytes);
         }
         this.encodingMessages.add(message);
@@ -239,7 +239,9 @@ public abstract class WriterImpl {
     }
 
     private void sendMessages(Queue<EnqueuedMessage> messages) {
-        logger.debug("Sending messages...");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Sending {} messages...", messages.size());
+        }
         YdbTopic.StreamWriteMessage.WriteRequest.Builder writeRequestBuilder = YdbTopic.StreamWriteMessage.WriteRequest
                 .newBuilder()
                 .setCodec(ProtoUtils.toProto(settings.getCodec()));
@@ -300,8 +302,8 @@ public abstract class WriterImpl {
         synchronized (incomingQueue) {
             currentInFlightCount -= messageCount;
             availableSizeBytes += sizeBytes;
-            if (logger.isDebugEnabled()) {
-                logger.debug("Freed {} bytes in {} messages. Current In-flight: {}, current availableSize: {}",
+            if (logger.isTraceEnabled()) {
+                logger.trace("Freed {} bytes in {} messages. Current In-flight: {}, current availableSize: {}",
                         sizeBytes, messageCount, currentInFlightCount, availableSizeBytes);
             }
 


### PR DESCRIPTION
- Fix available size handling in cases when compress size is larger than uncompressed
- Prevent write request from being sent without messages
- Fix write ack handling in cases when lowest received ack seqNo is not equal to seqNo of the oldest message waiting for ack
- Add isReconnecting flag to prevent stopping writer on error and sending messages while reconnecting
- Get rid of sentMessages synchronized block
- Add available size and in-flight logging, improve logging overall