### PR TITLE
Fix double transport closure

### DIFF
--- a/core/src/main/java/tech/ydb/core/impl/BaseGrpcTransport.java
+++ b/core/src/main/java/tech/ydb/core/impl/BaseGrpcTransport.java
@@ -36,7 +36,7 @@ public abstract class BaseGrpcTransport implements GrpcTransport {
             .withIssues(Issue.of("Request was not sent: transport is shutting down", Issue.Severity.ERROR)
     ));
 
-    private volatile boolean shutdown = false;
+    protected volatile boolean shutdown = false;
 
     public abstract AuthCallOptions getAuthCallOptions();
     abstract GrpcChannel getChannel(GrpcRequestSettings settings);

--- a/core/src/main/java/tech/ydb/core/impl/YdbTransportImpl.java
+++ b/core/src/main/java/tech/ydb/core/impl/YdbTransportImpl.java
@@ -122,6 +122,9 @@ public class YdbTransportImpl extends BaseGrpcTransport {
 
     @Override
     public void close() {
+        if (shutdown) {
+            return;
+        }
         super.close();
 
         periodicDiscoveryTask.stop();


### PR DESCRIPTION
There was an error on shutting down grpc channels if transport.close() was called more than once. The reason was that channels were shutting down on the scheduler which had already been shut down on first transport.close()