### PR TITLE
Fix: remove a race of read requests on restart

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -368,6 +368,7 @@ public abstract class WriterImpl {
             completeSession(Status.of(StatusCode.fromProto(message.getStatus()))
                             .withIssues(Issue.of("Got a message with non-success status: " + message,
                                     Issue.Severity.ERROR)), null);
+            return;
         }
         if (message.hasInitResponse()) {
             currentSessionId = message.getInitResponse().getSessionId();


### PR DESCRIPTION
There was a case where on reconnecting and initialising a new read session more data than needed could be requested due to a race between initial DataRequest and a DataRequest on finishing handling a message from previous session.