### PR TITLE
Allow to clear the settings defined in table's PartitioningSettings

### DIFF
--- a/table/src/main/java/tech/ydb/table/settings/PartitioningSettings.java
+++ b/table/src/main/java/tech/ydb/table/settings/PartitioningSettings.java
@@ -39,53 +39,28 @@ public class PartitioningSettings {
         return maxPartitionsCount;
     }
 
-    public PartitioningSettings setPartitioningBySize(boolean partitioningBySize) {
+    public PartitioningSettings setPartitioningBySize(Boolean partitioningBySize) {
         this.partitioningBySize = partitioningBySize;
         return this;
     }
 
-    public PartitioningSettings setPartitioningByLoad(boolean partitioningByLoad) {
+    public PartitioningSettings setPartitioningByLoad(Boolean partitioningByLoad) {
         this.partitioningByLoad = partitioningByLoad;
         return this;
     }
 
-    public PartitioningSettings setPartitionSize(long partitionSizeMb) {
+    public PartitioningSettings setPartitionSize(Long partitionSizeMb) {
         this.partitionSizeMb = partitionSizeMb;
         return this;
     }
 
-    public PartitioningSettings setMinPartitionsCount(long partitionsCount) {
+    public PartitioningSettings setMinPartitionsCount(Long partitionsCount) {
         this.minPartitionsCount = partitionsCount;
         return this;
     }
 
-    public PartitioningSettings setMaxPartitionsCount(long partitionsCount) {
+    public PartitioningSettings setMaxPartitionsCount(Long partitionsCount) {
         this.maxPartitionsCount = partitionsCount;
-        return this;
-    }
-
-    public PartitioningSettings clearPartitioningBySize() {
-        this.partitioningBySize = null;
-        return this;
-    }
-
-    public PartitioningSettings clearPartitioningByLoad() {
-        this.partitioningByLoad = null;
-        return this;
-    }
-
-    public PartitioningSettings clearPartitionSize() {
-        this.partitionSizeMb = null;
-        return this;
-    }
-
-    public PartitioningSettings clearMinPartitionsCount() {
-        this.minPartitionsCount = null;
-        return this;
-    }
-
-    public PartitioningSettings clearMaxPartitionsCount() {
-        this.maxPartitionsCount = null;
         return this;
     }
 }

--- a/table/src/main/java/tech/ydb/table/settings/PartitioningSettings.java
+++ b/table/src/main/java/tech/ydb/table/settings/PartitioningSettings.java
@@ -39,28 +39,53 @@ public class PartitioningSettings {
         return maxPartitionsCount;
     }
 
-    public PartitioningSettings setPartitioningBySize(Boolean partitioningBySize) {
+    public PartitioningSettings setPartitioningBySize(boolean partitioningBySize) {
         this.partitioningBySize = partitioningBySize;
         return this;
     }
 
-    public PartitioningSettings setPartitioningByLoad(Boolean partitioningByLoad) {
+    public PartitioningSettings setPartitioningByLoad(boolean partitioningByLoad) {
         this.partitioningByLoad = partitioningByLoad;
         return this;
     }
 
-    public PartitioningSettings setPartitionSize(Long partitionSizeMb) {
+    public PartitioningSettings setPartitionSize(long partitionSizeMb) {
         this.partitionSizeMb = partitionSizeMb;
         return this;
     }
 
-    public PartitioningSettings setMinPartitionsCount(Long partitionsCount) {
+    public PartitioningSettings setMinPartitionsCount(long partitionsCount) {
         this.minPartitionsCount = partitionsCount;
         return this;
     }
 
-    public PartitioningSettings setMaxPartitionsCount(Long partitionsCount) {
+    public PartitioningSettings setMaxPartitionsCount(long partitionsCount) {
         this.maxPartitionsCount = partitionsCount;
+        return this;
+    }
+
+    public PartitioningSettings clearPartitioningBySize() {
+        this.partitioningBySize = null;
+        return this;
+    }
+
+    public PartitioningSettings clearPartitioningByLoad() {
+        this.partitioningByLoad = null;
+        return this;
+    }
+
+    public PartitioningSettings clearPartitionSize() {
+        this.partitionSizeMb = null;
+        return this;
+    }
+
+    public PartitioningSettings clearMinPartitionsCount() {
+        this.minPartitionsCount = null;
+        return this;
+    }
+
+    public PartitioningSettings clearMaxPartitionsCount() {
+        this.maxPartitionsCount = null;
         return this;
     }
 }

--- a/table/src/main/java/tech/ydb/table/settings/PartitioningSettings.java
+++ b/table/src/main/java/tech/ydb/table/settings/PartitioningSettings.java
@@ -63,4 +63,29 @@ public class PartitioningSettings {
         this.maxPartitionsCount = partitionsCount;
         return this;
     }
+
+    public PartitioningSettings clearPartitioningBySize() {
+        this.partitioningBySize = null;
+        return this;
+    }
+
+    public PartitioningSettings clearPartitioningByLoad() {
+        this.partitioningByLoad = null;
+        return this;
+    }
+
+    public PartitioningSettings clearPartitionSize() {
+        this.partitionSizeMb = null;
+        return this;
+    }
+
+    public PartitioningSettings clearMinPartitionsCount() {
+        this.minPartitionsCount = null;
+        return this;
+    }
+
+    public PartitioningSettings clearMaxPartitionsCount() {
+        this.maxPartitionsCount = null;
+        return this;
+    }
 }


### PR DESCRIPTION
Currently the table's PartitioningSettings does not allow to reset (clear to null) its properties.
This may not be enough for some applications, and ALTER TABLE support in Spark Connector is one example of this.
Spark's ALTER TABLE syntax allows to both add and remove TBLPROPERTIES, which naturally translates to the removal of explicit values defined for table partitioning settings.