### PR TITLE
Fix unordered reading from a single partition in case of user errors

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/read/impl/AsyncReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/AsyncReaderImpl.java
@@ -84,7 +84,8 @@ public class AsyncReaderImpl extends ReaderImpl implements AsyncReader {
             } catch (Exception exception) {
                 String errorMessage = "Error in user DataReceivedEvent callback: " + exception;
                 logger.error(errorMessage);
-                shutdownImpl(errorMessage);
+                shutdownImpl(errorMessage).join();
+                throw exception;
             }
         }, handlerExecutor);
     }


### PR DESCRIPTION
After the merge of this PR, clients will wait until partition sessions are closed before completing DataReceivedEvent handling.
This is crucial due to the possibility of not completing future provided by the `shutdownImpl` until we will start invocation of the callback declared at the `tech/ydb/topic/read/impl/PartitionSessionImpl.java:313`

And, as a second update we will also rethrow an exception, so it can be logged with the stacktrace at the `tech/ydb/topic/read/impl/PartitionSessionImpl.java:314`

See also:
* `tech/ydb/topic/impl/GrpcStreamRetrier.java:95`
* `tech/ydb/topic/read/impl/PartitionSessionImpl.java:326`