### PR TITLE
Fixing race condition in AsyncReaderImpl::shutdown

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/read/impl/AsyncReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/AsyncReaderImpl.java
@@ -152,21 +152,21 @@ public class AsyncReaderImpl extends ReaderImpl implements AsyncReader {
         });
     }
 
-    protected void handleReaderClosed() {
-        handlerExecutor.execute(() -> {
+    protected CompletableFuture<Void> handleReaderClosed() {
+        return CompletableFuture.runAsync(() -> {
             try {
                 eventHandler.onReaderClosed(new ReaderClosedEvent());
             } catch (Throwable th) {
                 logUserThrowableAndStopWorking(th, "onReaderClosed");
                 throw th;
             }
-        });
+        }, handlerExecutor);
     }
 
     @Override
     protected void onShutdown(String reason) {
         super.onShutdown(reason);
-        handleReaderClosed();
+        handleReaderClosed().join();
         if (defaultHandlerExecutorService != null) {
             logger.debug("Shutting down default handler executor");
             defaultHandlerExecutorService.shutdown();


### PR DESCRIPTION
This PR fixes a race condition that occurs upon invocation of `AsyncReaderImpl::shutdown` when the `handlerExecutor` field is set.

The problem we faced:
1. User code calls `AsyncReaderImpl::shutdown`.
2. Then following call chain follows: `GrpcStreamRetrier::shutdownImpl` -> `AsyncReaderImpl::onShutdown` -> `AsyncReaderImpl::handleReaderClosed`.
3. `handleReaderClosed` sends an action calling `eventHandler.onReaderClosed` to `handlerExecutor` but does not wait for execution.
4. `AsyncReaderImpl::shutdown` returns.
5. User code shutdowns `handlerExecutor`.
6. `handlerExecutor` rejects the action from the third step and `eventHandler.onReaderClosed` is never called.