### PR TITLE
Add unique index support

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <ydb-auth-api.version>1.0.0</ydb-auth-api.version>
-        <ydb-proto-api.version>1.6.2</ydb-proto-api.version>
+        <ydb-proto-api.version>1.6.4</ydb-proto-api.version>
         <yc-auth.version>2.2.0</yc-auth.version>
     </properties>
 

--- a/table/src/main/java/tech/ydb/table/description/TableDescription.java
+++ b/table/src/main/java/tech/ydb/table/description/TableDescription.java
@@ -182,6 +182,16 @@ public class TableDescription {
             return this;
         }
 
+        public Builder addGlobalUniqueIndex(String name, List<String> columns) {
+            indexes.add(new TableIndex(name, columns, TableIndex.Type.GLOBAL_UNIQUE));
+            return this;
+        }
+
+        public Builder addGlobalUniqueIndex(String name, List<String> columns, List<String> dataColumns) {
+            indexes.add(new TableIndex(name, columns, dataColumns, TableIndex.Type.GLOBAL_UNIQUE));
+            return this;
+        }
+
         public Builder addGlobalAsyncIndex(String name, List<String> columns) {
             indexes.add(new TableIndex(name, columns, TableIndex.Type.GLOBAL_ASYNC));
             return this;

--- a/table/src/main/java/tech/ydb/table/description/TableIndex.java
+++ b/table/src/main/java/tech/ydb/table/description/TableIndex.java
@@ -12,8 +12,8 @@ public class TableIndex {
 
     public enum Type {
         GLOBAL,
-
         GLOBAL_ASYNC,
+        GLOBAL_UNIQUE,
     }
 
     /**

--- a/table/src/main/java/tech/ydb/table/impl/BaseSession.java
+++ b/table/src/main/java/tech/ydb/table/impl/BaseSession.java
@@ -234,6 +234,9 @@ public abstract class BaseSession implements Session {
         builder.addAllIndexColumns(index.getColumns());
         builder.addAllDataColumns(index.getDataColumns());
         switch (index.getType()) {
+            case GLOBAL_UNIQUE:
+                builder.setGlobalUniqueIndex(YdbTable.GlobalUniqueIndex.getDefaultInstance());
+                break;
             case GLOBAL_ASYNC:
                 builder.setGlobalAsyncIndex(YdbTable.GlobalAsyncIndex.getDefaultInstance());
                 break;
@@ -564,6 +567,10 @@ public abstract class BaseSession implements Session {
 
             if (idx.hasGlobalAsyncIndex()) {
                 description.addGlobalAsyncIndex(idx.getName(), idx.getIndexColumnsList(), idx.getDataColumnsList());
+            }
+
+            if (idx.hasGlobalUniqueIndex()) {
+                description.addGlobalUniqueIndex(idx.getName(), idx.getIndexColumnsList(), idx.getDataColumnsList());
             }
         }
         YdbTable.TableStats tableStats = result.getTableStats();

--- a/table/src/main/java/tech/ydb/table/settings/AlterTableSettings.java
+++ b/table/src/main/java/tech/ydb/table/settings/AlterTableSettings.java
@@ -90,6 +90,16 @@ public class AlterTableSettings extends RequestSettings<AlterTableSettings> {
         return this;
     }
 
+    public AlterTableSettings addGlobalUiniqueIndex(String name, List<String> columns) {
+        addIndexes.put(name, new TableIndex(name, columns, TableIndex.Type.GLOBAL_UNIQUE));
+        return this;
+    }
+
+    public AlterTableSettings addGlobalUniqueIndex(String name, List<String> columns, List<String> dataColumns) {
+        addIndexes.put(name, new TableIndex(name, columns, dataColumns, TableIndex.Type.GLOBAL_UNIQUE));
+        return this;
+    }
+
     public AlterTableSettings addGlobalAsyncIndex(String name, List<String> columns) {
         addIndexes.put(name, new TableIndex(name, columns, TableIndex.Type.GLOBAL_ASYNC));
         return this;


### PR DESCRIPTION
Since 24.1 ydb has option to enable unique constraint. This commit allows to create table with unique constraint or add it by alter table call