### PR TITLE
Support for using ip address in discovery response.

### DIFF
--- a/core/src/main/java/tech/ydb/core/impl/pool/EndpointRecord.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/EndpointRecord.java
@@ -9,20 +9,20 @@ public class EndpointRecord {
     private final String host;
     private final String hostAndPort;
     private final String locationDC;
-    private final String sslNameOverride;
+    private final String authority;
     private final int port;
     private final int nodeId;
 
-    public EndpointRecord(String host, int port, int nodeId, String locationDC, String sslNameOverride) {
+    public EndpointRecord(String host, int port, int nodeId, String locationDC, String authority) {
         this.host = Objects.requireNonNull(host);
         this.port = port;
         this.hostAndPort = host + ":" + port;
         this.nodeId = nodeId;
         this.locationDC = locationDC;
-        if (sslNameOverride != null && !sslNameOverride.isEmpty()) {
-            this.sslNameOverride = sslNameOverride;
+        if (authority != null && !authority.isEmpty()) {
+            this.authority = authority;
         } else {
-            this.sslNameOverride = null;
+            this.authority = null;
         }
     }
 
@@ -34,8 +34,8 @@ public class EndpointRecord {
         return host;
     }
 
-    public String getSslNameOverride() {
-        return sslNameOverride;
+    public String getAuthority() {
+        return authority;
     }
 
     public int getPort() {
@@ -57,6 +57,6 @@ public class EndpointRecord {
     @Override
     public String toString() {
         return "Endpoint{host=" + host + ", port=" + port + ", node=" + nodeId +
-            ", location=" + locationDC + ", sslNameOverride=" + sslNameOverride + "}";
+            ", location=" + locationDC + ", overrideAuthority=" + authority + "}";
     }
 }

--- a/core/src/main/java/tech/ydb/core/impl/pool/EndpointRecord.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/EndpointRecord.java
@@ -9,23 +9,33 @@ public class EndpointRecord {
     private final String host;
     private final String hostAndPort;
     private final String locationDC;
+    private final String sslNameOverride;
     private final int port;
     private final int nodeId;
 
-    public EndpointRecord(String host, int port, int nodeId, String locationDC) {
+    public EndpointRecord(String host, int port, int nodeId, String locationDC, String sslNameOverride) {
         this.host = Objects.requireNonNull(host);
         this.port = port;
         this.hostAndPort = host + ":" + port;
         this.nodeId = nodeId;
         this.locationDC = locationDC;
+        if (sslNameOverride != null && !sslNameOverride.isEmpty()) {
+            this.sslNameOverride = sslNameOverride;
+        } else {
+            this.sslNameOverride = null;
+        }
     }
 
     public EndpointRecord(String host, int port) {
-        this(host, port, 0, null);
+        this(host, port, 0, null, null);
     }
 
     public String getHost() {
         return host;
+    }
+
+    public String getSslNameOverride() {
+        return sslNameOverride;
     }
 
     public int getPort() {
@@ -46,6 +56,7 @@ public class EndpointRecord {
 
     @Override
     public String toString() {
-        return "Endpoint{host=" + host + ", port=" + port + ", node=" + nodeId + ", location=" + locationDC + "}";
+        return "Endpoint{host=" + host + ", port=" + port + ", node=" + nodeId +
+            ", location=" + locationDC + ", sslNameOverride=" + sslNameOverride + "}";
     }
 }

--- a/core/src/main/java/tech/ydb/core/impl/pool/GrpcChannel.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/GrpcChannel.java
@@ -28,7 +28,8 @@ public class GrpcChannel {
         try {
             logger.debug("Creating grpc channel with {}", endpoint);
             this.endpoint = endpoint;
-            this.channel = factory.newManagedChannel(endpoint.getHost(), endpoint.getPort());
+            this.channel = factory.newManagedChannel(endpoint.getHost(), endpoint.getPort(),
+                endpoint.getSslNameOverride());
             this.connectTimeoutMs = factory.getConnectTimeoutMs();
             this.readyWatcher = new ReadyWatcher();
             this.readyWatcher.checkState();

--- a/core/src/main/java/tech/ydb/core/impl/pool/GrpcChannel.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/GrpcChannel.java
@@ -29,7 +29,7 @@ public class GrpcChannel {
             logger.debug("Creating grpc channel with {}", endpoint);
             this.endpoint = endpoint;
             this.channel = factory.newManagedChannel(endpoint.getHost(), endpoint.getPort(),
-                endpoint.getSslNameOverride());
+                endpoint.getAuthority());
             this.connectTimeoutMs = factory.getConnectTimeoutMs();
             this.readyWatcher = new ReadyWatcher();
             this.readyWatcher.checkState();

--- a/core/src/main/java/tech/ydb/core/impl/pool/ManagedChannelFactory.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/ManagedChannelFactory.java
@@ -13,7 +13,7 @@ public interface ManagedChannelFactory {
         ManagedChannelFactory buildFactory(GrpcTransportBuilder builder);
     }
 
-    ManagedChannel newManagedChannel(String host, int port, String sslHostOverride);
+    ManagedChannel newManagedChannel(String host, int port, String authority);
 
     long getConnectTimeoutMs();
 }

--- a/core/src/main/java/tech/ydb/core/impl/pool/ManagedChannelFactory.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/ManagedChannelFactory.java
@@ -13,7 +13,7 @@ public interface ManagedChannelFactory {
         ManagedChannelFactory buildFactory(GrpcTransportBuilder builder);
     }
 
-    ManagedChannel newManagedChannel(String host, int port);
+    ManagedChannel newManagedChannel(String host, int port, String sslHostOverride);
 
     long getConnectTimeoutMs();
 }

--- a/core/src/main/java/tech/ydb/core/impl/pool/NettyChannelFactory.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/NettyChannelFactory.java
@@ -58,7 +58,7 @@ public class NettyChannelFactory implements ManagedChannelFactory {
 
     @SuppressWarnings("deprecation")
     @Override
-    public ManagedChannel newManagedChannel(String host, int port) {
+    public ManagedChannel newManagedChannel(String host, int port, String sslHostOverride) {
         NettyChannelBuilder channelBuilder = NettyChannelBuilder
                 .forAddress(host, port);
 
@@ -66,6 +66,9 @@ public class NettyChannelFactory implements ManagedChannelFactory {
             channelBuilder
                     .negotiationType(NegotiationType.TLS)
                     .sslContext(createSslContext());
+            if (sslHostOverride != null) {
+                channelBuilder.overrideAuthority(sslHostOverride);
+            }
         } else {
             channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
         }

--- a/core/src/main/java/tech/ydb/core/impl/pool/ShadedNettyChannelFactory.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/ShadedNettyChannelFactory.java
@@ -58,7 +58,7 @@ public class ShadedNettyChannelFactory implements ManagedChannelFactory {
 
     @SuppressWarnings("deprecation")
     @Override
-    public ManagedChannel newManagedChannel(String host, int port) {
+    public ManagedChannel newManagedChannel(String host, int port, String sslHostOverride) {
         NettyChannelBuilder channelBuilder = NettyChannelBuilder
                 .forAddress(host, port);
 
@@ -66,6 +66,9 @@ public class ShadedNettyChannelFactory implements ManagedChannelFactory {
             channelBuilder
                     .negotiationType(NegotiationType.TLS)
                     .sslContext(createSslContext());
+            if (sslHostOverride != null) {
+                channelBuilder.overrideAuthority(sslHostOverride);
+            }
         } else {
             channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
         }

--- a/core/src/test/java/tech/ydb/core/impl/YdbDiscoveryTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/YdbDiscoveryTest.java
@@ -40,7 +40,7 @@ public class YdbDiscoveryTest {
         Mockito.when(channel.shutdownNow()).thenReturn(channel);
         Mockito.when(channel.awaitTermination(Mockito.anyLong(), Mockito.any())).thenReturn(true);
 
-        Mockito.when(channelFactory.newManagedChannel(Mockito.any(), Mockito.anyInt())).thenReturn(channel);
+        Mockito.when(channelFactory.newManagedChannel(Mockito.any(), Mockito.anyInt(), Mockito.isNull())).thenReturn(channel);
     }
 
     private <T extends Throwable> T checkFutureException(CompletableFuture<Boolean> f, String message, Class<T> clazz) {

--- a/core/src/test/java/tech/ydb/core/impl/YdbTransportImplTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/YdbTransportImplTest.java
@@ -51,9 +51,9 @@ public class YdbTransportImplTest {
         Mockito.when(transportChannel.shutdownNow()).thenReturn(transportChannel);
         Mockito.when(transportChannel.awaitTermination(Mockito.anyLong(), Mockito.any())).thenReturn(true);
 
-        Mockito.when(channelFactory.newManagedChannel(Mockito.eq("mocked"), Mockito.eq(2136)))
+        Mockito.when(channelFactory.newManagedChannel(Mockito.eq("mocked"), Mockito.eq(2136), Mockito.isNull()))
                 .thenReturn(discoveryChannel);
-        Mockito.when(channelFactory.newManagedChannel(Mockito.eq("node"), Mockito.eq(2136)))
+        Mockito.when(channelFactory.newManagedChannel(Mockito.eq("node"), Mockito.eq(2136), Mockito.isNull()))
                 .thenReturn(transportChannel);
     }
 

--- a/core/src/test/java/tech/ydb/core/impl/pool/DefaultChannelFactoryTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/DefaultChannelFactoryTest.java
@@ -76,7 +76,7 @@ public class DefaultChannelFactoryTest {
         channelStaticMock.verify(FOR_ADDRESS, times(0));
 
         Assert.assertEquals(30_000l, factory.getConnectTimeoutMs());
-        Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT));
+        Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT, null));
 
         channelStaticMock.verify(FOR_ADDRESS, times(1));
 
@@ -100,7 +100,7 @@ public class DefaultChannelFactoryTest {
         channelStaticMock.verify(FOR_ADDRESS, times(0));
 
         Assert.assertEquals(60000l, factory.getConnectTimeoutMs());
-        Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT));
+        Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT, null));
 
         channelStaticMock.verify(FOR_ADDRESS, times(1));
 
@@ -124,7 +124,7 @@ public class DefaultChannelFactoryTest {
 
         channelStaticMock.verify(FOR_ADDRESS, times(0));
 
-        Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT));
+        Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT, null));
 
         channelStaticMock.verify(FOR_ADDRESS, times(1));
 
@@ -150,7 +150,7 @@ public class DefaultChannelFactoryTest {
             ManagedChannelFactory factory = ChannelFactoryLoader.load().buildFactory(builder);
 
             Assert.assertEquals(4000l, factory.getConnectTimeoutMs());
-            Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT));
+            Assert.assertSame(channelMock, factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT, null));
 
         } finally {
             selfSignedCert.delete();
@@ -176,7 +176,7 @@ public class DefaultChannelFactoryTest {
         ManagedChannelFactory factory = ChannelFactoryLoader.load().buildFactory(builder);
 
         RuntimeException ex = Assert.assertThrows(RuntimeException.class,
-                () -> factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT));
+                () -> factory.newManagedChannel(MOCKED_HOST, MOCKED_PORT, null));
 
         Assert.assertEquals("cannot create ssl context", ex.getMessage());
         Assert.assertNotNull(ex.getCause());

--- a/core/src/test/java/tech/ydb/core/impl/pool/EndpointPoolTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/EndpointPoolTest.java
@@ -208,8 +208,8 @@ public class EndpointPoolTest {
         check(pool.getEndpoint(2)).hostname("n2.ydb.tech").nodeID(2).port(12342);
 
         // Pessimize unknown nodes - nothing is changed
-        pool.pessimizeEndpoint(new EndpointRecord("n2.ydb.tech", 12341, 2, null));
-        pool.pessimizeEndpoint(new EndpointRecord("n2.ydb.tech", 12342, 2, null));
+        pool.pessimizeEndpoint(new EndpointRecord("n2.ydb.tech", 12341, 2, null, null));
+        pool.pessimizeEndpoint(new EndpointRecord("n2.ydb.tech", 12342, 2, null, null));
         pool.pessimizeEndpoint(null);
         check(pool).records(5).knownNodes(5).needToReDiscovery(false).bestEndpointsCount(4);
 
@@ -553,6 +553,6 @@ public class EndpointPoolTest {
     }
 
     private static EndpointRecord endpoint(int nodeID, String hostname, int port, String location) {
-        return new EndpointRecord(hostname, port, nodeID, location);
+        return new EndpointRecord(hostname, port, nodeID, location, null);
     }
 }

--- a/core/src/test/java/tech/ydb/core/impl/pool/GrpcChannelPoolTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/GrpcChannelPoolTest.java
@@ -23,7 +23,7 @@ public class GrpcChannelPoolTest {
     @Before
     public void setUp() {
         Mockito.when(factoryMock.getConnectTimeoutMs()).thenReturn(500l); // timeout for ready watcher
-        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt()))
+        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt(), Mockito.isNull()))
                 .then((args) -> ManagedChannelMock.good());
     }
 
@@ -34,8 +34,8 @@ public class GrpcChannelPoolTest {
 
     @Test
     public void simpleTest() {
-        EndpointRecord e1 = new EndpointRecord("host1", 1234, 10, null);
-        EndpointRecord e2 = new EndpointRecord("host1", 1235, 11, null);
+        EndpointRecord e1 = new EndpointRecord("host1", 1234, 10, null, null);
+        EndpointRecord e2 = new EndpointRecord("host1", 1235, 11, null, null);
 
         GrpcChannelPool pool = new GrpcChannelPool(factoryMock, scheduler);
         Assert.assertEquals(0, pool.getChannels().size());
@@ -66,9 +66,9 @@ public class GrpcChannelPoolTest {
 
     @Test
     public void removeChannels() {
-        EndpointRecord e1 = new EndpointRecord("host1", 1234, 10, null);
-        EndpointRecord e2 = new EndpointRecord("host1", 1235, 11, null);
-        EndpointRecord e3 = new EndpointRecord("host1", 1236, 12, null);
+        EndpointRecord e1 = new EndpointRecord("host1", 1234, 10, null, null);
+        EndpointRecord e2 = new EndpointRecord("host1", 1235, 11, null, null);
+        EndpointRecord e3 = new EndpointRecord("host1", 1236, 12, null, null);
 
         GrpcChannelPool pool = new GrpcChannelPool(factoryMock, scheduler);
         Assert.assertEquals(0, pool.getChannels().size());
@@ -121,13 +121,13 @@ public class GrpcChannelPoolTest {
 
     @Test
     public void badShutdownTest() {
-        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt())).thenReturn(
+        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt(), Mockito.isNull())).thenReturn(
                 ManagedChannelMock.good(), ManagedChannelMock.good(),
                 ManagedChannelMock.wrongShutdown(), ManagedChannelMock.wrongShutdown());
 
-        EndpointRecord e1 = new EndpointRecord("host1", 1234, 10, null);
-        EndpointRecord e2 = new EndpointRecord("host1", 1235, 11, null);
-        EndpointRecord e3 = new EndpointRecord("host1", 1236, 12, null);
+        EndpointRecord e1 = new EndpointRecord("host1", 1234, 10, null, null);
+        EndpointRecord e2 = new EndpointRecord("host1", 1235, 11, null, null);
+        EndpointRecord e3 = new EndpointRecord("host1", 1236, 12, null, null);
 
         GrpcChannelPool pool = new GrpcChannelPool(factoryMock, scheduler);
         Assert.assertEquals(0, pool.getChannels().size());

--- a/core/src/test/java/tech/ydb/core/impl/pool/GrpcChannelTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/GrpcChannelTest.java
@@ -84,7 +84,7 @@ public class GrpcChannelTest {
         Assert.assertEquals(endpoint, channel.getEndpoint());
 
         RuntimeException ex1 = Assert.assertThrows(RuntimeException.class, channel::getReadyChannel);
-        Assert.assertEquals("Channel Endpoint{host=host1, port=1234, node=0, location=null, sslNameOverride=null} connecting problem",
+        Assert.assertEquals("Channel Endpoint{host=host1, port=1234, node=0, location=null, overrideAuthority=null} connecting problem",
                 ex1.getMessage());
 
         channel.shutdown();

--- a/core/src/test/java/tech/ydb/core/impl/pool/GrpcChannelTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/GrpcChannelTest.java
@@ -26,7 +26,7 @@ public class GrpcChannelTest {
 
     @Test
     public void goodChannels() {
-        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt()))
+        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt(), Mockito.isNull()))
                 .thenReturn(ManagedChannelMock.good(), ManagedChannelMock.good());
 
         EndpointRecord endpoint = new EndpointRecord("host1", 1234);
@@ -52,7 +52,7 @@ public class GrpcChannelTest {
                 ConnectivityState.READY,
         };
 
-        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt()))
+        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt(), Mockito.isNull()))
                 .thenReturn(new ManagedChannelMock(ConnectivityState.IDLE).nextStates(states))
                 .thenReturn(new ManagedChannelMock(ConnectivityState.IDLE).nextStates(states));
 
@@ -74,7 +74,7 @@ public class GrpcChannelTest {
                 ConnectivityState.SHUTDOWN,
         };
 
-        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt()))
+        Mockito.when(factoryMock.newManagedChannel(Mockito.any(), Mockito.anyInt(), Mockito.isNull()))
                 .thenReturn(new ManagedChannelMock(ConnectivityState.IDLE).nextStates(states))
                 .thenReturn(new ManagedChannelMock(ConnectivityState.IDLE).nextStates(states));
 
@@ -84,7 +84,7 @@ public class GrpcChannelTest {
         Assert.assertEquals(endpoint, channel.getEndpoint());
 
         RuntimeException ex1 = Assert.assertThrows(RuntimeException.class, channel::getReadyChannel);
-        Assert.assertEquals("Channel Endpoint{host=host1, port=1234, node=0, location=null} connecting problem",
+        Assert.assertEquals("Channel Endpoint{host=host1, port=1234, node=0, location=null, sslNameOverride=null} connecting problem",
                 ex1.getMessage());
 
         channel.shutdown();

--- a/core/src/test/java/tech/ydb/core/impl/pool/ManagedChannelMock.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/ManagedChannelMock.java
@@ -145,7 +145,7 @@ public class ManagedChannelMock extends ManagedChannel {
 
     public static ManagedChannelFactory.Builder MOCKED = (GrpcTransportBuilder builder) -> new ManagedChannelFactory() {
         @Override
-        public ManagedChannel newManagedChannel(String host, int port) {
+        public ManagedChannel newManagedChannel(String host, int port, String sslHostOverride) {
             return good();
         }
 

--- a/core/src/test/java/tech/ydb/core/impl/pool/ManagedChannelMock.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/ManagedChannelMock.java
@@ -145,7 +145,7 @@ public class ManagedChannelMock extends ManagedChannel {
 
     public static ManagedChannelFactory.Builder MOCKED = (GrpcTransportBuilder builder) -> new ManagedChannelFactory() {
         @Override
-        public ManagedChannel newManagedChannel(String host, int port, String sslHostOverride) {
+        public ManagedChannel newManagedChannel(String host, int port, String authority) {
             return good();
         }
 

--- a/core/src/test/java/tech/ydb/core/impl/pool/PriorityPickerTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/PriorityPickerTest.java
@@ -49,7 +49,7 @@ public class PriorityPickerTest {
 
     @Test
     public void detectLocalDCfallbackTest() {
-        List<EndpointRecord> single = Collections.singletonList(new EndpointRecord("localhost", 8080, 0, "DC1"));
+        List<EndpointRecord> single = Collections.singletonList(new EndpointRecord("localhost", 8080, 0, "DC1", null));
         PriorityPicker ignoreSelftLocation = PriorityPicker.from(BalancingSettings.detectLocalDs(), "DC1", single);
 
         Assert.assertEquals(0, ignoreSelftLocation.getEndpointPriority("DC1"));
@@ -73,7 +73,7 @@ public class PriorityPickerTest {
             final int port = serverSocket.getLocalPort();
 
             List<EndpointRecord> records = Arrays.asList("DC1", "DC1", "DC2", "DC2", "DC2", "DC3")
-                    .stream().map(location -> new EndpointRecord("localhost", port, 1, location))
+                    .stream().map(location -> new EndpointRecord("localhost", port, 1, location, null))
                     .collect(Collectors.toList());
 
             String localDC = PriorityPicker.detectLocalDC(records, testTicker);


### PR DESCRIPTION
This feature allow server to explicit show own ip address to set connection instead of DNS hostname resolving. Usefull in case of connection to k8s clusters where nodes (k8s pod) placed in cluster.local domain so external user has no ability to resolve it.