### PR TITLE
Replacing synchronized blocks with ReentrantLocks in topic-related part of SDK

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -102,7 +102,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
 
     public CompletableFuture<Void> tryToEnqueue(EnqueuedMessage message, boolean instant) {
         incomingQueueLock.lock();
-        
+
         try {
             if (currentInFlightCount >= settings.getMaxSendBufferMessagesCount()) {
                 if (instant) {
@@ -193,7 +193,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
         boolean haveNewMessagesToSend = false;
         // Working with encodingMessages under incomingQueueLock to prevent deadlocks while working with free method
         incomingQueueLock.lock();
-        
+
         try {
             // Taking all encoded messages to sending queue
             while (true) {
@@ -274,7 +274,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
             return CompletableFuture.completedFuture(null);
         }
         incomingQueueLock.lock();
-        
+
         try {
             return this.lastAcceptedMessageFuture.isDone()
                     ? CompletableFuture.completedFuture(null)
@@ -286,7 +286,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
 
     private void free(int messageCount, long sizeBytes) {
         incomingQueueLock.lock();
-        
+
         try {
             currentInFlightCount -= messageCount;
             availableSizeBytes += sizeBytes;

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -191,8 +191,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
 
     private void moveEncodedMessagesToSendingQueue() {
         boolean haveNewMessagesToSend = false;
-        // Working with encodingMessages under synchronized incomingQueue to prevent deadlocks
-        // while working with free method
+        // Working with encodingMessages under incomingQueueLock to prevent deadlocks while working with free method
         incomingQueueLock.lock();
         
         try {


### PR DESCRIPTION
As [mentioned](https://docs.oracle.com/en/java/javase/21/core/virtual-threads.html#GUID-704A716D-0662-4BC7-8C7F-66EE74B1EDAD) in Java's official virtual threads tutorial, `synchonized` blocks reduce benefits of virtual threads'. In this PR, I've replaced all `synchronized` blocks in topic-related part of SDK with `ReentrantLock`s.