### PR TITLE
Replacing synchronized blocks with ReentrantLocks in core part of SDK

### DIFF
--- a/core/src/main/java/tech/ydb/core/impl/call/ReadStreamCall.java
+++ b/core/src/main/java/tech/ydb/core/impl/call/ReadStreamCall.java
@@ -3,7 +3,6 @@ package tech.ydb.core.impl.call;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.Nullable;
 
@@ -30,7 +29,6 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
 
     private final String traceId;
     private final ClientCall<ReqT, RespT> call;
-    private final ReentrantLock callLock = new ReentrantLock();
     private final GrpcStatusHandler statusConsumer;
     private final ReqT request;
     private final Metadata headers;
@@ -58,27 +56,25 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
             throw new IllegalStateException("Read stream call is already started");
         }
 
-        callLock.lock();
-
-        try {
-            call.start(this, headers);
-            call.request(1);
-            if (logger.isTraceEnabled()) {
-                logger.trace("ReadStreamCall[{}] --> {}", traceId, TextFormat.shortDebugString((Message) request));
-            }
-            call.sendMessage(request);
-            // close stream by client side
-            call.halfClose();
-        } catch (Throwable t) {
+        synchronized (call) {
             try {
-                call.cancel(null, t);
-            } catch (Throwable ex) {
-                logger.error("ReadStreamCall[{}] got exception while canceling", traceId, ex);
-            }
+                call.start(this, headers);
+                call.request(1);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("ReadStreamCall[{}] --> {}", traceId, TextFormat.shortDebugString((Message) request));
+                }
+                call.sendMessage(request);
+                // close stream by client side
+                call.halfClose();
+            } catch (Throwable t) {
+                try {
+                    call.cancel(null, t);
+                } catch (Throwable ex) {
+                    logger.error("ReadStreamCall[{}] got exception while canceling", traceId, ex);
+                }
 
-            statusFuture.completeExceptionally(t);
-        } finally {
-            callLock.unlock();
+                statusFuture.completeExceptionally(t);
+            }
         }
 
         return statusFuture;
@@ -86,12 +82,8 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
 
     @Override
     public void cancel() {
-        callLock.lock();
-
-        try {
+        synchronized (call) {
             call.cancel("Cancelled on user request", new CancellationException());
-        } finally {
-            callLock.unlock();
         }
     }
 
@@ -103,23 +95,18 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
             }
             observerReference.get().onNext(message);
             // request delivery of the next inbound message.
-            callLock.lock();
-
-            try {
+            synchronized (call) {
                 call.request(1);
-            } finally {
-                callLock.unlock();
             }
         } catch (Exception ex) {
             statusFuture.completeExceptionally(ex);
-            callLock.lock();
 
             try {
-                call.cancel("Canceled by exception from observer", ex);
+                synchronized (call) {
+                    call.cancel("Canceled by exception from observer", ex);
+                }
             } catch (Throwable th) {
                 logger.error("ReadStreamCall[{}] got exception while canceling", traceId, th);
-            } finally {
-                callLock.unlock();
             }
         }
     }

--- a/core/src/main/java/tech/ydb/core/impl/call/ReadWriteStreamCall.java
+++ b/core/src/main/java/tech/ydb/core/impl/call/ReadWriteStreamCall.java
@@ -28,6 +28,7 @@ import tech.ydb.core.impl.auth.AuthCallOptions;
  * @param <W> type of message to be sent to the server
  */
 public class ReadWriteStreamCall<R, W> extends ClientCall.Listener<R> implements GrpcReadWriteStream<R, W> {
+    // GrpcTransport's logger is used intentionally
     private static final Logger logger = LoggerFactory.getLogger(GrpcTransport.class);
 
     private final String traceId;
@@ -159,7 +160,7 @@ public class ReadWriteStreamCall<R, W> extends ClientCall.Listener<R> implements
     @Override
     public void onClose(io.grpc.Status status, @Nullable Metadata trailers) {
         if (logger.isTraceEnabled()) {
-            logger.trace("ReadWriteStreamCall[{}] closed with status {}", status);
+            logger.trace("ReadWriteStreamCall[{}] closed with status {}", traceId, status);
         }
         statusConsumer.accept(status, trailers);
 


### PR DESCRIPTION
Continuation of https://github.com/ydb-platform/ydb-java-sdk/pull/338