### PR TITLE
Logging improvements for topic reader & writer

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/impl/GrpcStreamRetrier.java
+++ b/topic/src/main/java/tech/ydb/topic/impl/GrpcStreamRetrier.java
@@ -1,6 +1,6 @@
 package tech.ydb.topic.impl;
 
-import java.util.UUID;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -22,6 +22,9 @@ public abstract class GrpcStreamRetrier {
     private static final int EXP_BACKOFF_BASE_MS = 256;
     private static final int EXP_BACKOFF_CEILING_MS = 40000; // 40 sec (max delays would be 40-80 sec)
     private static final int EXP_BACKOFF_MAX_POWER = 7;
+    private static final int ID_LENGTH = 50;
+    private static final char[] ID_ALPHABET = "abcdefghijklmnopqrstuvwxyzABSDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+            .toCharArray();
 
     protected final String id;
     protected final AtomicBoolean isReconnecting = new AtomicBoolean(false);
@@ -31,7 +34,11 @@ public abstract class GrpcStreamRetrier {
 
     protected GrpcStreamRetrier(ScheduledExecutorService scheduler) {
         this.scheduler = scheduler;
-        this.id = UUID.randomUUID().toString();
+        this.id = new Random().ints(0, ID_ALPHABET.length)
+                .limit(ID_LENGTH)
+                .map(charId -> ID_ALPHABET[charId])
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
     }
 
     protected abstract Logger getLogger();

--- a/topic/src/main/java/tech/ydb/topic/read/impl/CommitterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/CommitterImpl.java
@@ -29,10 +29,8 @@ public class CommitterImpl {
 
     public CompletableFuture<Void> commitImpl(boolean fromCommitter) {
         if (logger.isDebugEnabled()) {
-            logger.debug("[{}] partition session {} (partition {}): committing {} message(s), offsets" +
-                            " [{},{})" + (fromCommitter ? " from Committer" : ""), partitionSession.getPath(),
-                    partitionSession.getId(), partitionSession.getPartitionId(), messageCount,
-                    offsetsToCommit.getStart(), offsetsToCommit.getEnd());
+            logger.debug("[{}] Committing {} message(s), offsets [{},{})" + (fromCommitter ? " from Committer" : ""),
+                    partitionSession.getFullId(), messageCount, offsetsToCommit.getStart(), offsetsToCommit.getEnd());
         }
         return partitionSession.commitOffsetRange(offsetsToCommit);
     }

--- a/topic/src/main/java/tech/ydb/topic/read/impl/DeferredCommitterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/DeferredCommitterImpl.java
@@ -41,9 +41,9 @@ public class DeferredCommitterImpl implements DeferredCommitter {
                     rangesLock.unlock();
                 }
             } catch (RuntimeException exception) {
-                String errorMessage = "Error adding new offset range to DeferredCommitter for partition session " +
-                        partitionSession.getId() + " (partition " + partitionSession.getPartitionId() + "): " +
-                        exception.getMessage();
+                String errorMessage = "[" + partitionSession.getFullId() + "] Error adding new offset range to " +
+                        "DeferredCommitter for partition session " + partitionSession.getId() + " (partition " +
+                        partitionSession.getPartitionId() + "): " + exception.getMessage();
                 logger.error(errorMessage);
                 throw new RuntimeException(errorMessage, exception);
             }

--- a/topic/src/main/java/tech/ydb/topic/read/impl/PartitionSessionImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/PartitionSessionImpl.java
@@ -38,6 +38,7 @@ public class PartitionSessionImpl {
     private static final Logger logger = LoggerFactory.getLogger(PartitionSessionImpl.class);
 
     private final long id;
+    private final String fullId;
     private final String path;
     private final long partitionId;
     private final PartitionSession sessionInfo;
@@ -58,6 +59,7 @@ public class PartitionSessionImpl {
 
     private PartitionSessionImpl(Builder builder) {
         this.id = builder.id;
+        this.fullId = builder.fullId;
         this.path = builder.path;
         this.partitionId = builder.partitionId;
         this.sessionInfo = new PartitionSession(id, partitionId, path);
@@ -66,8 +68,8 @@ public class PartitionSessionImpl {
         this.decompressionExecutor = builder.decompressionExecutor;
         this.dataEventCallback = builder.dataEventCallback;
         this.commitFunction = builder.commitFunction;
-        logger.info("[{}] Partition session {} (partition {}) is started. CommittedOffset: {}. " +
-                "Partition offsets: {}-{}", path, id, partitionId, lastReadOffset, builder.partitionOffsets.getStart(),
+        logger.info("[{}] Partition session for {} is started. CommittedOffset: {}. " +
+                "Partition offsets: {}-{}", fullId, path, lastReadOffset, builder.partitionOffsets.getStart(),
                 builder.partitionOffsets.getEnd());
     }
 
@@ -76,6 +78,10 @@ public class PartitionSessionImpl {
     }
 
     public long getId() {
+        return id;
+    }
+
+    public long getFullId() {
         return id;
     }
 
@@ -110,13 +116,11 @@ public class PartitionSessionImpl {
             List<YdbTopic.StreamReadMessage.ReadResponse.MessageData> batchMessages = batch.getMessageDataList();
             if (!batchMessages.isEmpty()) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("[{}] Received a batch of {} messages (offsets {} - {}) for partition session {} " +
-                                    "(partition {})", path, batchMessages.size(), batchMessages.get(0).getOffset(),
-                            batchMessages.get(batchMessages.size() - 1).getOffset(), id, partitionId);
+                    logger.debug("[{}] Received a batch of {} messages (offsets {} - {})", fullId, batchMessages.size(),
+                            batchMessages.get(0).getOffset(), batchMessages.get(batchMessages.size() - 1).getOffset());
                 }
             } else {
-                logger.error("[{}] Received empty batch for partition session {} (partition {}). This shouldn't happen",
-                        path, id, partitionId);
+                logger.error("[{}] Received empty batch. This shouldn't happen", fullId);
             }
             batchMessages.forEach(messageData -> {
                 long commitOffsetFrom = lastReadOffset;
@@ -125,14 +129,12 @@ public class PartitionSessionImpl {
                 if (newReadOffset > lastReadOffset) {
                     lastReadOffset = newReadOffset;
                     if (logger.isTraceEnabled()) {
-                        logger.trace("[{}] Received a message with offset {} for partition session {} " +
-                                        "(partition {}). lastReadOffset is now {}", path, messageOffset, id,
-                                partitionId, lastReadOffset);
+                        logger.trace("[{}] Received a message with offset {}. lastReadOffset is now {}", fullId,
+                                messageOffset, lastReadOffset);
                     }
                 } else {
-                    logger.error("[{}] Received a message with offset {} which is less than last read offset {} " +
-                                    "for partition session {} (partition {})", path, messageOffset, lastReadOffset, id,
-                            partitionId);
+                    logger.error("[{}] Received a message with offset {} which is less than last read offset {} ",
+                            fullId, messageOffset, lastReadOffset);
                 }
                 newBatch.addMessage(new MessageImpl.Builder()
                         .setBatchMeta(batchMeta)
@@ -175,10 +177,9 @@ public class PartitionSessionImpl {
                                     decodingBatches.remove();
                                     if (logger.isTraceEnabled()) {
                                         List<MessageImpl> messages = decodingBatch.getMessages();
-                                        logger.trace("[{}] Adding batch with offsets {}-{} to reading queue of " +
-                                                        "partition session {} (partition {})", path,
+                                        logger.trace("[{}] Adding batch with offsets {}-{} to reading queue", fullId,
                                                 messages.get(0).getOffset(),
-                                                messages.get(messages.size() - 1).getOffset(), id, partitionId);
+                                                messages.get(messages.size() - 1).getOffset());
                                     }
                                     readingQueue.add(decodingBatch);
                                     haveNewBatchesReady = true;
@@ -206,16 +207,14 @@ public class PartitionSessionImpl {
         try {
             if (isWorking.get()) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("[{}] Offset range [{}, {}) is requested to be committed for partition session {} " +
-                                    "(partition {}). Last committed offset is {} (commit lag is {})", path,
-                            rangeToCommit.getStart(), rangeToCommit.getEnd(), id, partitionId, lastCommittedOffset,
-                            rangeToCommit.getStart() - lastCommittedOffset);
+                    logger.debug("[{}] Offset range [{}, {}) is requested to be committed. Last committed offset is" +
+                                    " {} (commit lag is {})", fullId, rangeToCommit.getStart(), rangeToCommit.getEnd(),
+                            lastCommittedOffset, rangeToCommit.getStart() - lastCommittedOffset);
                 }
                 commitFutures.put(rangeToCommit.getEnd(), resultFuture);
             } else {
-                logger.info("[{}] Offset range [{}, {}) is requested to be committed, but partition session {} " +
-                        "(partition {}) is already closed", path, rangeToCommit.getStart(), rangeToCommit.getEnd(), id,
-                        partitionId);
+                logger.info("[{}] Offset range [{}, {}) is requested to be committed, but partition session " +
+                        "is already closed", fullId, rangeToCommit.getStart(), rangeToCommit.getEnd());
                 resultFuture.completeExceptionally(new RuntimeException("Partition session " + id + " (partition " +
                         partitionId + ") for " + path + " is already closed"));
                 return resultFuture;
@@ -233,18 +232,16 @@ public class PartitionSessionImpl {
     public void commitOffsetRanges(List<OffsetsRange> rangesToCommit) {
         if (isWorking.get()) {
             if (logger.isInfoEnabled()) {
-                StringBuilder message = new StringBuilder("[").append(path)
-                        .append("] Sending CommitRequest for partition session ").append(id)
-                        .append(" (partition ").append(partitionId).append(") with offset ranges ");
+                StringBuilder message = new StringBuilder("[").append(fullId)
+                        .append("] Sending CommitRequest with offset ranges ");
                 addRangesToString(message, rangesToCommit);
                 logger.debug(message.toString());
             }
             commitFunction.accept(rangesToCommit);
         } else if (logger.isInfoEnabled()) {
-            StringBuilder message = new StringBuilder("[").append(path).append("] Offset ranges ");
+            StringBuilder message = new StringBuilder("[").append(fullId).append("] Offset ranges ");
             addRangesToString(message, rangesToCommit);
-            message.append(" are requested to be committed, but partition session ").append(id)
-                    .append(" (partition ").append(partitionId).append(") is already closed");
+            message.append(" are requested to be committed, but partition session is already closed");
             logger.info(message.toString());
         }
     }
@@ -261,17 +258,15 @@ public class PartitionSessionImpl {
 
     public void handleCommitResponse(long committedOffset) {
         if (committedOffset <= lastCommittedOffset) {
-            logger.error("[{}] Commit response received for partition session {} (partition {}). Committed offset: {}" +
-                            " which is not greater than previous committed offset: {}.", path, id, partitionId,
-                    committedOffset, lastCommittedOffset);
+            logger.error("[{}] Commit response received. Committed offset: {} which is less than previous " +
+                    "committed offset: {}.", fullId, committedOffset, lastCommittedOffset);
             return;
         }
         Map<Long, CompletableFuture<Void>> futuresToComplete = commitFutures.headMap(committedOffset, true);
         if (logger.isDebugEnabled()) {
-            logger.debug("[{}] Commit response received for partition session {} (partition {}). Committed offset: {}" +
-                            ". Previous committed offset: {} (diff is {} message(s)). Completing {} commit futures",
-                    path, id, partitionId, committedOffset, lastCommittedOffset, committedOffset - lastCommittedOffset,
-                    futuresToComplete.size());
+            logger.debug("[{}] Commit response received. Committed offset: {}. Previous committed offset: {} " +
+                            "(diff is {} message(s)). Completing {} commit futures", fullId, committedOffset,
+                    lastCommittedOffset, committedOffset - lastCommittedOffset, futuresToComplete.size());
         }
         lastCommittedOffset = committedOffset;
         futuresToComplete.values().forEach(future -> future.complete(null));
@@ -280,7 +275,7 @@ public class PartitionSessionImpl {
 
     private void decode(Batch batch) {
         if (logger.isTraceEnabled()) {
-            logger.trace("[{}] Started decoding batch for partition session {} (partition {})", path, id, partitionId);
+            logger.trace("[{}] Started decoding batch", fullId);
         }
         if (batch.getCodec() == Codec.RAW) {
             return;
@@ -292,14 +287,13 @@ public class PartitionSessionImpl {
                 message.setDecompressed(true);
             } catch (IOException exception) {
                 message.setException(exception);
-                logger.info("[{}] Exception was thrown while decoding a message in partition session {} " +
-                        "(partition {})", path, id, partitionId);
+                logger.warn("[{}] Exception was thrown while decoding a message: ", fullId, exception);
             }
         });
         batch.setDecompressed(true);
 
         if (logger.isTraceEnabled()) {
-            logger.trace("[{}] Finished decoding batch for partition session {} (partition {})", path, id, partitionId);
+            logger.trace("[{}] Finished decoding batch", fullId);
         }
     }
 
@@ -320,23 +314,22 @@ public class PartitionSessionImpl {
                     messageImplList.get(messageImplList.size() - 1).getOffset() + 1);
             DataReceivedEvent event = new DataReceivedEventImpl(this, messagesToRead, offsetsToCommit);
             if (logger.isDebugEnabled()) {
-                logger.debug("[{}] DataReceivedEvent callback with {} message(s) (offsets {}-{}) for partition " +
-                                "session {} " + "(partition {}) is about to be called...", path, messagesToRead.size(),
-                        messagesToRead.get(0).getOffset(), messagesToRead.get(messagesToRead.size() - 1).getOffset(),
-                        id, partitionId);
+                logger.debug("[{}] DataReceivedEvent callback with {} message(s) (offsets {}-{}) is about " +
+                                "to be called...", fullId, messagesToRead.size(),messagesToRead.get(0).getOffset(),
+                        messagesToRead.get(messagesToRead.size() - 1).getOffset());
             }
             dataEventCallback.apply(event)
                     .whenComplete((res, th) -> {
                         if (th != null) {
-                            logger.error("[{}] DataReceivedEvent callback with {} message(s) (offsets {}-{}) for " +
-                                    "partition session {} (partition {}) finished with error: ", path,
-                                    messagesToRead.size(), messagesToRead.get(0).getOffset(),
-                                    messagesToRead.get(messagesToRead.size() - 1).getOffset(), id, partitionId, th);
+                            logger.error("[{}] DataReceivedEvent callback with {} message(s) (offsets {}-{}) finished" +
+                                            " with error: ", fullId, messagesToRead.size(),
+                                    messagesToRead.get(0).getOffset(),
+                                    messagesToRead.get(messagesToRead.size() - 1).getOffset(), th);
                         } else if (logger.isDebugEnabled()) {
-                            logger.debug("[{}] DataReceivedEvent callback with {} message(s) (offsets {}-{}) for " +
-                                    "partition session {} (partition {}) successfully finished", path,
-                                    messagesToRead.size(), messagesToRead.get(0).getOffset(),
-                                    messagesToRead.get(messagesToRead.size() - 1).getOffset(), id, partitionId);
+                            logger.debug("[{}] DataReceivedEvent callback with {} message(s) (offsets {}-{}) " +
+                                            "successfully finished", fullId, messagesToRead.size(),
+                                    messagesToRead.get(0).getOffset(),
+                                    messagesToRead.get(messagesToRead.size() - 1).getOffset());
                         }
                         isReadingNow.set(false);
                         batchToRead.complete();
@@ -344,8 +337,7 @@ public class PartitionSessionImpl {
                     });
         } else {
             if (logger.isTraceEnabled()) {
-                logger.trace("[{}] Partition session {} (partition {}) - no need to send data to readers: " +
-                        "reading is already being performed", path, id, partitionId);
+                logger.trace("[{}] No need to send data to readers: reading is already being performed", fullId);
             }
         }
     }
@@ -355,8 +347,8 @@ public class PartitionSessionImpl {
 
         try {
             isWorking.set(false);
-            logger.info("[{}] Partition session {} (partition {}) is shutting down. Failing {} commit futures...", path,
-                    id, partitionId, commitFutures.size());
+            logger.info("[{}] Partition session for {} is shutting down. Failing {} commit futures...", fullId,
+                    path, commitFutures.size());
             commitFutures.values().forEach(f -> f.completeExceptionally(new RuntimeException("Partition session " + id +
                     " (partition " + partitionId + ") for " + path + " is closed")));
         } finally {
@@ -378,6 +370,7 @@ public class PartitionSessionImpl {
      */
     public static class Builder {
         private long id;
+        private String fullId;
         private String path;
         private long partitionId;
         private long committedOffset;
@@ -388,6 +381,11 @@ public class PartitionSessionImpl {
 
         public Builder setId(long id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder setFullId(String fullId) {
+            this.fullId = fullId;
             return this;
         }
 

--- a/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
@@ -52,6 +52,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
 
     // Every reading stream has a sequential number (for debug purposes)
     private final AtomicLong seqNumberCounter = new AtomicLong(0);
+    private final String consumerName;
 
     public ReaderImpl(TopicRpc topicRpc, ReaderSettings settings) {
         super(topicRpc.getScheduler());
@@ -79,8 +80,10 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
         }
         if (settings.getConsumerName() != null) {
             message.append(" and Consumer: \"").append(settings.getConsumerName()).append("\"");
+            consumerName = settings.getConsumerName();
         } else {
             message.append(" without a Consumer");
+            consumerName = "NoConsumer";
         }
         logger.info(message.toString());
     }
@@ -209,7 +212,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
     }
 
     protected class ReadSessionImpl extends ReadSession {
-        protected String sessionId = "";
+        protected String sessionId;
         // Total size to request with next ReadRequest.
         // Used to group several ReadResponses in one on high rps
         private final AtomicLong sizeBytesToRequest = new AtomicLong(0);
@@ -220,7 +223,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
 
         @Override
         public void startAndInitialize() {
-            logger.debug("[{}] Session {} startAndInitialize called", streamId, sessionId);
+            logger.debug("[{}] Session startAndInitialize called", streamId);
             start(this::processMessage).whenComplete(this::closeDueToError);
 
             YdbTopic.StreamReadMessage.InitRequest.Builder initRequestBuilder = YdbTopic.StreamReadMessage.InitRequest
@@ -273,15 +276,13 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
         private void sendStartPartitionSessionResponse(PartitionSessionImpl partitionSession,
                                                          StartPartitionSessionSettings startSettings) {
             if (!isWorking.get()) {
-                logger.info("[{}] Need to send StartPartitionSessionResponse for partition session {} (partition {})," +
-                        " but reading session is already closed", streamId, partitionSession.getId(),
-                        partitionSession.getPartitionId());
+                logger.info("[{}] Need to send StartPartitionSessionResponse, but reading session is already closed",
+                        partitionSession.getFullId());
                 return;
             }
             if (!partitionSessions.containsKey(partitionSession.getId())) {
-                logger.info("[{}] Need to send StartPartitionSessionResponse for partition session {} (partition {})," +
-                                " but have no such partition session active", streamId, partitionSession.getId(),
-                        partitionSession.getPartitionId());
+                logger.info("[{}] Need to send StartPartitionSessionResponse, but have no such active partition " +
+                        "session anymore", partitionSession.getFullId());
                 return;
             }
             YdbTopic.StreamReadMessage.StartPartitionSessionResponse.Builder responseBuilder =
@@ -301,9 +302,8 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
                     partitionSession.setLastCommittedOffset(userDefinedCommitOffset);
                 }
             }
-            logger.info("[{}] Sending StartPartitionSessionResponse for partition session {} (partition {})" +
-                            " with readOffset {} and commitOffset {}", streamId, partitionSession.getId(),
-                    partitionSession.getPartitionId(), userDefinedReadOffset, userDefinedCommitOffset);
+            logger.info("[{}] Sending StartPartitionSessionResponse with readOffset {} and commitOffset {}",
+                    partitionSession.getFullId(), userDefinedReadOffset, userDefinedCommitOffset);
             send(YdbTopic.StreamReadMessage.FromClient.newBuilder()
                     .setStartPartitionSessionResponse(responseBuilder.build())
                     .build());
@@ -318,8 +318,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             PartitionSessionImpl partitionSession = partitionSessions.remove(partitionSessionId);
             if (partitionSession != null) {
                 partitionSession.shutdown();
-                logger.info("[{}] Sending StopPartitionSessionResponse for partition session {} (partition {})",
-                        streamId, partitionSessionId, partitionSession.getPartitionId());
+                logger.info("[{}] Sending StopPartitionSessionResponse", partitionSession.getFullId());
             } else {
                 logger.warn("[{}] Sending StopPartitionSessionResponse for partition session {}, " +
                         "but have no such partition session active", streamId, partitionSessionId);
@@ -392,13 +391,16 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
         private void onStartPartitionSessionRequest(YdbTopic.StreamReadMessage.StartPartitionSessionRequest request) {
             long partitionSessionId = request.getPartitionSession().getPartitionSessionId();
             long partitionId = request.getPartitionSession().getPartitionId();
-            logger.info("[{}] Received StartPartitionSessionRequest: partition session {} (partition {}) " +
-                            "with committedOffset {} and partitionOffsets [{}-{})", streamId,
+            String partitionSessionFullId = streamId + '/' + partitionSessionId + "-p" + partitionId;
+            logger.info("[{}] Received StartPartitionSessionRequest for Topic {} and Consumer {}. " +
+                            "Partition session {} (partition {}) with committedOffset {} and partitionOffsets [{}-{})",
+                    partitionSessionFullId, request.getPartitionSession().getPath(), consumerName,
                     partitionSessionId, partitionId, request.getCommittedOffset(),
                     request.getPartitionOffsets().getStart(), request.getPartitionOffsets().getEnd());
 
             PartitionSessionImpl partitionSession = PartitionSessionImpl.newBuilder()
                     .setId(partitionSessionId)
+                    .setFullId(partitionSessionFullId)
                     .setPath(request.getPartitionSession().getPath())
                     .setPartitionId(partitionId)
                     .setCommittedOffset(request.getCommittedOffset())
@@ -418,8 +420,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             if (request.getGraceful()) {
                 PartitionSessionImpl partitionSession = partitionSessions.get(request.getPartitionSessionId());
                 if (partitionSession != null) {
-                    logger.info("[{}] Received graceful StopPartitionSessionRequest for partition session {} " +
-                            "(partition {})", streamId, partitionSession.getId(), partitionSession.getPartitionId());
+                    logger.info("[{}] Received graceful StopPartitionSessionRequest", partitionSession.getFullId());
                     handleStopPartitionSession(request, partitionSession.getSessionInfo(),
                             () -> sendStopPartitionSessionResponse(request.getPartitionSessionId()));
                 } else {
@@ -433,8 +434,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             } else {
                 PartitionSessionImpl partitionSession = partitionSessions.remove(request.getPartitionSessionId());
                 if (partitionSession != null) {
-                    logger.info("[{}] Received force StopPartitionSessionRequest for partition session {} (partition " +
-                                    "{})", streamId, partitionSession.getId(), partitionSession.getPartitionId());
+                    logger.info("[{}] Received force StopPartitionSessionRequest", partitionSession.getFullId());
                     closePartitionSession(partitionSession);
                 } else {
                     logger.info("[{}] Received force StopPartitionSessionRequest for partition session {}, " +

--- a/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
@@ -71,7 +71,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             message.append(" \"").append(settings.getReaderName()).append("\"");
         }
         message.append(" (generated id ").append(id).append(")");
-        message.append(" created for topic(s): ");
+        message.append(" created for Topic(s) ");
         for (TopicReadSettings topic : settings.getTopics()) {
             if (topic != settings.getTopics().get(0)) {
                 message.append(", ");
@@ -79,7 +79,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             message.append("\"").append(topic.getPath()).append("\"");
         }
         if (settings.getConsumerName() != null) {
-            message.append(" and Consumer: \"").append(settings.getConsumerName()).append("\"");
+            message.append(" and Consumer \"").append(settings.getConsumerName());
             consumerName = settings.getConsumerName();
         } else {
             message.append(" without a Consumer");
@@ -392,7 +392,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             long partitionSessionId = request.getPartitionSession().getPartitionSessionId();
             long partitionId = request.getPartitionSession().getPartitionId();
             String partitionSessionFullId = streamId + '/' + partitionSessionId + "-p" + partitionId;
-            logger.info("[{}] Received StartPartitionSessionRequest for Topic {} and Consumer {}. " +
+            logger.info("[{}] Received StartPartitionSessionRequest for Topic \"{}\" and Consumer \"{}\". " +
                             "Partition session {} (partition {}) with committedOffset {} and partitionOffsets [{}-{})",
                     partitionSessionFullId, request.getPartitionSession().getPath(), consumerName,
                     partitionSessionId, partitionId, request.getCommittedOffset(),
@@ -401,7 +401,7 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             PartitionSessionImpl partitionSession = PartitionSessionImpl.newBuilder()
                     .setId(partitionSessionId)
                     .setFullId(partitionSessionFullId)
-                    .setPath(request.getPartitionSession().getPath())
+                    .setTopicPath(request.getPartitionSession().getPath())
                     .setPartitionId(partitionId)
                     .setCommittedOffset(request.getCommittedOffset())
                     .setPartitionOffsets(new OffsetsRangeImpl(request.getPartitionOffsets().getStart(),

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -413,8 +413,9 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
             sessionId = response.getSessionId();
             long lastSeqNo = response.getLastSeqNo();
             long actualLastSeqNo = lastSeqNo;
-            logger.info("[{}] Session initialized with id {} (partition {}), lastSeqNo {}, actualLastSeqNo {}",
-                    streamId, sessionId, response.getPartitionId(), lastSeqNo, actualLastSeqNo);
+            logger.info("[{}] Session with id {} (partition {}) initialized for topic \"{}\", lastSeqNo {}," +
+                            " actualLastSeqNo {}", streamId, sessionId, response.getPartitionId(),
+                    settings.getTopicPath(), lastSeqNo, actualLastSeqNo);
             // If there are messages that were already sent before reconnect but haven't received acks,
             // their highest seqNo should also be taken in consideration when calculating next seqNo automatically
             if (!sentMessages.isEmpty()) {

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -336,7 +336,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
     }
 
     private class WriteSessionImpl extends WriteSession {
-        protected String sessionId = "";
+        protected String sessionId;
         private final MessageSender messageSender;
         private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
@@ -347,7 +347,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
 
         @Override
         public void startAndInitialize() {
-            logger.debug("[{}] Session {} startAndInitialize called", streamId, sessionId);
+            logger.debug("[{}] Session startAndInitialize called", streamId);
             start(this::processMessage).whenComplete(this::closeDueToError);
 
             YdbTopic.StreamWriteMessage.InitRequest.Builder initRequestBuilder = YdbTopic.StreamWriteMessage.InitRequest
@@ -375,8 +375,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
         private void sendDataRequestIfNeeded() {
             while (true) {
                 if (!isInitialized.get()) {
-                    logger.debug("[{}] Can't send data: current session is not yet initialized",
-                            streamId);
+                    logger.debug("[{}] Can't send data: current session is not yet initialized", streamId);
                     return;
                 }
                 if (!isWorking.get()) {
@@ -412,9 +411,10 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
 
         private void onInitResponse(YdbTopic.StreamWriteMessage.InitResponse response) {
             sessionId = response.getSessionId();
-            logger.info("[{}] Session {} initialized (partition {})", streamId, sessionId, response.getPartitionId());
             long lastSeqNo = response.getLastSeqNo();
             long actualLastSeqNo = lastSeqNo;
+            logger.info("[{}] Session initialized with id {} (partition {}), lastSeqNo {}, actualLastSeqNo {}",
+                    streamId, sessionId, response.getPartitionId(), lastSeqNo, actualLastSeqNo);
             // If there are messages that were already sent before reconnect but haven't received acks,
             // their highest seqNo should also be taken in consideration when calculating next seqNo automatically
             if (!sentMessages.isEmpty()) {
@@ -425,7 +425,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
             // TODO: remember supported codecs for further validation
             if (!sentMessages.isEmpty()) {
                 // resending messages that haven't received acks yet
-                logger.info("Resending {} messages that haven't received ack's yet into new session...",
+                logger.info("[{}] Resending {} messages that haven't received ack's yet into new session...", fullId,
                         sentMessages.size());
                 messageSender.sendMessages(sentMessages);
             }

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -412,7 +412,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
 
         private void onInitResponse(YdbTopic.StreamWriteMessage.InitResponse response) {
             sessionId = response.getSessionId();
-            logger.info("[{}] Session {} initialized", streamId, sessionId);
+            logger.info("[{}] Session {} initialized (partition {})", streamId, sessionId, response.getPartitionId());
             long lastSeqNo = response.getLastSeqNo();
             long actualLastSeqNo = lastSeqNo;
             // If there are messages that were already sent before reconnect but haven't received acks,

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -426,7 +426,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
             // TODO: remember supported codecs for further validation
             if (!sentMessages.isEmpty()) {
                 // resending messages that haven't received acks yet
-                logger.info("[{}] Resending {} messages that haven't received ack's yet into new session...", fullId,
+                logger.info("[{}] Resending {} messages that haven't received ack's yet into new session...", streamId,
                         sentMessages.size());
                 messageSender.sendMessages(sentMessages);
             }


### PR DESCRIPTION
Example:
`[9ka8R7.1/2-p8] Received StartPartitionSessionRequest for Topic "ydb-test/test-topic" and Consumer "/ydb-test/test-consumer". Partition session 2 (partition 8) with committedOffset 173587 and partitionOffsets [173587-173587)`
`9ka8R7`: reader generated random id
`1`: stream id (increments with each reconnect)
`2`: Partition session id. Set by server
`p8`: partition id (`8`)