### PR TITLE
Fix commit for executeDataQueryAndCommit

### DIFF
--- a/table/src/main/java/tech/ydb/table/transaction/TableTransaction.java
+++ b/table/src/main/java/tech/ydb/table/transaction/TableTransaction.java
@@ -84,7 +84,7 @@ public interface TableTransaction extends YdbTransaction {
      * @return a future to query result
      */
     default CompletableFuture<Result<DataQueryResult>> executeDataQueryAndCommit(String query, Params params) {
-        return executeDataQuery(query, false, params, new ExecuteDataQuerySettings());
+        return executeDataQuery(query, true, params, new ExecuteDataQuerySettings());
     }
 
     CompletableFuture<Status> commit(CommitTxSettings settings);


### PR DESCRIPTION
Just as a reminder, executeDataQuery's signature looks like this - https://github.com/ydb-platform/ydb-java-sdk/blob/master/table/src/main/java/tech/ydb/table/impl/BaseSession.java#L1210-L1211

```
        public CompletableFuture<Result<DataQueryResult>> executeDataQuery(
                String query, boolean commitAtEnd, Params params, ExecuteDataQuerySettings settings) {
```