### PR TITLE
Handle write acks from YDB server during transactions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <ydb-auth-api.version>1.0.0</ydb-auth-api.version>
-        <ydb-proto-api.version>1.6.4</ydb-proto-api.version>
+        <ydb-proto-api.version>1.7.0</ydb-proto-api.version>
         <yc-auth.version>2.2.0</yc-auth.version>
     </properties>
 

--- a/topic/src/main/java/tech/ydb/topic/write/WriteAck.java
+++ b/topic/src/main/java/tech/ydb/topic/write/WriteAck.java
@@ -16,7 +16,8 @@ public class WriteAck {
 
     public enum State {
         WRITTEN,
-        ALREADY_WRITTEN
+        ALREADY_WRITTEN,
+        WRITTEN_IN_TX
     }
 
     public static class Details {

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -516,7 +516,9 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
                             return;
                     }
                     break;
-
+                case WRITTEN_IN_TX:
+                    resultAck = new WriteAck(ack.getSeqNo(), WriteAck.State.WRITTEN_IN_TX, null);
+                    break;
                 default:
                     message.getFuture().completeExceptionally(
                             new RuntimeException("Unknown WriteAck state"));


### PR DESCRIPTION
This PR adds handling for the WRITTEN_IN_TX state in write sessions.

Background:
- When using write operations with transactions, the YDB Server returns a `WRITTEN_IN_TX` state
- Currently, this state is not handled, causing a RuntimeException("Unknown WriteAck state")
- This makes the system unstable when using transactions with write sessions

Changes:
- Added a new case branch to handle the WRITTEN_IN_TX state
- This state occurs after joining on CompletableFuture<WriteAck> for send calls within transactions

Impact:
This change will improve stability for applications using transactions with write sessions.
