### PR TITLE
Prevent Virtual Thread Deadlocks by Replacing Synchronized Blocks

### DIFF
--- a/core/src/main/java/tech/ydb/core/impl/call/ReadStreamCall.java
+++ b/core/src/main/java/tech/ydb/core/impl/call/ReadStreamCall.java
@@ -3,6 +3,8 @@ package tech.ydb.core.impl.call;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.Nullable;
 
@@ -29,6 +31,7 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
 
     private final String traceId;
     private final ClientCall<ReqT, RespT> call;
+    private final Lock callLock = new ReentrantLock();
     private final GrpcStatusHandler statusConsumer;
     private final ReqT request;
     private final Metadata headers;
@@ -56,7 +59,8 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
             throw new IllegalStateException("Read stream call is already started");
         }
 
-        synchronized (call) {
+        callLock.lock();
+
             try {
                 call.start(this, headers);
                 if (logger.isTraceEnabled()) {
@@ -74,16 +78,21 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
                 }
 
                 statusFuture.completeExceptionally(t);
+            } finally {
+                callLock.unlock();
             }
-        }
+
 
         return statusFuture;
     }
 
     @Override
     public void cancel() {
-        synchronized (call) {
+        callLock.lock();
+        try {
             call.cancel("Cancelled on user request", new CancellationException());
+        } finally {
+            callLock.unlock();
         }
     }
 
@@ -95,15 +104,21 @@ public class ReadStreamCall<ReqT, RespT> extends ClientCall.Listener<RespT> impl
             }
             observerReference.get().onNext(message);
             // request delivery of the next inbound message.
-            synchronized (call) {
+            callLock.lock();
+            try {
                 call.request(1);
+            } finally {
+                callLock.unlock();
             }
         } catch (Exception ex) {
             statusFuture.completeExceptionally(ex);
 
             try {
-                synchronized (call) {
+                callLock.lock();
+                try {
                     call.cancel("Canceled by exception from observer", ex);
+                } finally {
+                    callLock.unlock();
                 }
             } catch (Throwable th) {
                 logger.error("ReadStreamCall[{}] got exception while canceling", traceId, th);

--- a/core/src/main/java/tech/ydb/core/impl/call/ReadWriteStreamCall.java
+++ b/core/src/main/java/tech/ydb/core/impl/call/ReadWriteStreamCall.java
@@ -70,22 +70,20 @@ public class ReadWriteStreamCall<R, W> extends ClientCall.Listener<R> implements
         }
 
         callLock.lock();
-
+        try {
+            call.start(this, headers);
+            call.request(1);
+        } catch (Throwable t) {
             try {
-                call.start(this, headers);
-                call.request(1);
-            } catch (Throwable t) {
-                try {
-                    call.cancel(null, t);
-                } catch (Throwable ex) {
-                    logger.error("Exception encountered while closing the unary call", ex);
-                }
-
-                statusFuture.completeExceptionally(t);
-            } finally {
-
-                callLock.unlock();
+                call.cancel(null, t);
+            } catch (Throwable ex) {
+                logger.error("Exception encountered while closing the unary call", ex);
             }
+
+            statusFuture.completeExceptionally(t);
+        } finally {
+            callLock.unlock();
+        }
 
         return statusFuture;
     }

--- a/tests/junit5-support/src/main/java/tech/ydb/test/junit5/GrpcTransportExtension.java
+++ b/tests/junit5-support/src/main/java/tech/ydb/test/junit5/GrpcTransportExtension.java
@@ -65,7 +65,7 @@ public class GrpcTransportExtension extends ProxyGrpcTransport implements Execut
         holder.after(ec);
     }
 
-    private class Holder {
+    private static class Holder {
         private final Lock holderLock = new ReentrantLock();
 
         private YdbHelper helper = null;

--- a/tests/junit5-support/src/main/java/tech/ydb/test/junit5/GrpcTransportExtension.java
+++ b/tests/junit5-support/src/main/java/tech/ydb/test/junit5/GrpcTransportExtension.java
@@ -1,5 +1,8 @@
 package tech.ydb.test.junit5;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -14,9 +17,6 @@ import tech.ydb.core.grpc.GrpcTransport;
 import tech.ydb.test.integration.YdbHelper;
 import tech.ydb.test.integration.YdbHelperFactory;
 import tech.ydb.test.integration.utils.ProxyGrpcTransport;
-
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  *

--- a/tests/junit5-support/src/main/java/tech/ydb/test/junit5/GrpcTransportExtension.java
+++ b/tests/junit5-support/src/main/java/tech/ydb/test/junit5/GrpcTransportExtension.java
@@ -15,6 +15,9 @@ import tech.ydb.test.integration.YdbHelper;
 import tech.ydb.test.integration.YdbHelperFactory;
 import tech.ydb.test.integration.utils.ProxyGrpcTransport;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  *
  * @author Aleksandr Gorshenin
@@ -63,53 +66,70 @@ public class GrpcTransportExtension extends ProxyGrpcTransport implements Execut
     }
 
     private class Holder {
+        private final Lock holderLock = new ReentrantLock();
+
         private YdbHelper helper = null;
         private GrpcTransport transport = null;
         private ExtensionContext context = null;
 
-        public synchronized void before(ExtensionContext ec) {
-            if (helper != null) {
-                return;
-            }
-
-            YdbHelperFactory factory = YdbHelperFactory.getInstance();
-            helper = factory.createHelper();
-            if (helper != null) {
-                context = ec;
-
-                String path = "";
-                if (ec.getTestClass().isPresent()) {
-                    path += "/" + ec.getTestClass().get().getName();
+        public void before(ExtensionContext ec) {
+            holderLock.lock();
+            try {
+                if (helper != null) {
+                    return;
                 }
-                if (ec.getTestMethod().isPresent()) {
-                    path += "/" + ec.getTestMethod().get().getName();
-                }
+                YdbHelperFactory factory = YdbHelperFactory.getInstance();
+                helper = factory.createHelper();
+                if (helper != null) {
+                    context = ec;
 
-                logger.debug("create ydb helper for path {}", path);
-                transport = helper.createTransport();
+                    String path = "";
+                    if (ec.getTestClass().isPresent()) {
+                        path += "/" + ec.getTestClass().get().getName();
+                    }
+                    if (ec.getTestMethod().isPresent()) {
+                        path += "/" + ec.getTestMethod().get().getName();
+                    }
+
+                    logger.debug("create ydb helper for path {}", path);
+                    transport = helper.createTransport();
+                }
+            } finally {
+                holderLock.unlock();
             }
         }
 
-        public synchronized void after(ExtensionContext ec) {
-            if (context != ec) {
-                return;
-            }
+        public void after(ExtensionContext ec) {
+            holderLock.lock();
 
-            if (transport != null) {
-                transport.close();
-                transport = null;
-            }
+            try {
+                if (context != ec) {
+                    return;
+                }
 
-            if (helper != null) {
-                helper.close();
-                helper = null;
-            }
+                if (transport != null) {
+                    transport.close();
+                    transport = null;
+                }
 
-            context = null;
+                if (helper != null) {
+                    helper.close();
+                    helper = null;
+                }
+
+                context = null;
+            } finally {
+                holderLock.unlock();
+            }
         }
 
-        public synchronized GrpcTransport transport() {
-            return transport;
+        public GrpcTransport transport() {
+            holderLock.lock();
+            try {
+                return transport;
+            } finally {
+                holderLock.unlock();
+            }
         }
     }
 }

--- a/tests/junit5-support/src/main/java/tech/ydb/test/junit5/YdbHelperExtension.java
+++ b/tests/junit5-support/src/main/java/tech/ydb/test/junit5/YdbHelperExtension.java
@@ -1,5 +1,8 @@
 package tech.ydb.test.junit5;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -13,9 +16,6 @@ import org.slf4j.LoggerFactory;
 import tech.ydb.test.integration.YdbHelper;
 import tech.ydb.test.integration.YdbHelperFactory;
 import tech.ydb.test.integration.utils.ProxyYdbHelper;
-
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author Aleksandr Gorshenin

--- a/tests/junit5-support/src/main/java/tech/ydb/test/junit5/YdbHelperExtension.java
+++ b/tests/junit5-support/src/main/java/tech/ydb/test/junit5/YdbHelperExtension.java
@@ -63,7 +63,7 @@ public class YdbHelperExtension extends ProxyYdbHelper implements ExecutionCondi
         holder.after(ec);
     }
 
-    private class Holder {
+    private static class Holder {
         private final Lock holderLock = new ReentrantLock();
 
         private YdbHelper helper = null;


### PR DESCRIPTION
This PR replaces synchronized blocks in the YDB SDK with ReentrantLock implementations to resolve deadlocks that occur when using AsyncReader with Java 23 virtual threads. Synchronized blocks inadvertently pin virtual threads to carrier threads, leading to thread starvation in high-concurrency scenarios.

This change unblocks adoption of virtual threads in YDB applications while maintaining backward compatibility.

Example stacktrace of the pinned virtual thread
```
#329476554 "reader-session-8/f998jjgudtv9jk4kf359-executor-worker-33912448" virtual
      java.base/jdk.internal.misc.Unsafe.park(Native Method)
      java.base/java.lang.VirtualThread.parkOnCarrierThread(VirtualThread.java:680)
      java.base/java.lang.VirtualThread.park(VirtualThread.java:612)
      java.base/java.lang.System$2.parkVirtualThread(System.java:2735)
      java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:54)
      java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:219)
      java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
      java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:990)
      java.base/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:154)
      java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:323)
      io.netty.buffer.PoolSubpage.lock(PoolSubpage.java:294)
      io.netty.buffer.PoolArena.tcacheAllocateSmall(PoolArena.java:160)
      io.netty.buffer.PoolArena.allocate(PoolArena.java:135)
      io.netty.buffer.PoolArena.allocate(PoolArena.java:127)
      io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:403)
      io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188)
      io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:124)
      io.grpc.netty.NettyWritableBufferAllocator.allocate(NettyWritableBufferAllocator.java:51)
      io.grpc.internal.MessageFramer.writeKnownLengthUncompressed(MessageFramer.java:226)
      io.grpc.internal.MessageFramer.writeUncompressed(MessageFramer.java:172)
      io.grpc.internal.MessageFramer.writePayload(MessageFramer.java:143)
      io.grpc.internal.AbstractStream.writeMessage(AbstractStream.java:66)
      io.grpc.internal.ForwardingClientStream.writeMessage(ForwardingClientStream.java:37)
      io.grpc.internal.RetriableStream.sendMessage(RetriableStream.java:575)
      io.grpc.internal.ClientCallImpl.sendMessageInternal(ClientCallImpl.java:522)
      io.grpc.internal.ClientCallImpl.sendMessage(ClientCallImpl.java:510)
      io.grpc.ForwardingClientCall.sendMessage(ForwardingClientCall.java:37)
      io.grpc.ForwardingClientCall.sendMessage(ForwardingClientCall.java:37)
      [...]
      io.grpc.ForwardingClientCall.sendMessage(ForwardingClientCall.java:37)
      tech.ydb.core.impl.call.ReadWriteStreamCall.sendNext(ReadWriteStreamCall.java:95) // the thread is pinned here
      tech.ydb.topic.impl.SessionBase.send(SessionBase.java:80)
      tech.ydb.topic.read.impl.ReaderImpl$ReadSessionImpl.sendReadRequest(ReaderImpl.java:269)
      tech.ydb.topic.read.impl.ReaderImpl$ReadSessionImpl.lambda$onReadResponse$6(ReaderImpl.java:472)
      [...]
      tech.ydb.topic.read.impl.Batch.complete(Batch.java:32)
      tech.ydb.topic.read.impl.PartitionSessionImpl.lambda$sendDataToReadersIfNeeded$7(PartitionSessionImpl.java:337)
      [...]
      java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:314)
      java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
```