### PR TITLE
335.support pool

### DIFF
--- a/query/src/main/java/tech/ydb/query/impl/SessionImpl.java
+++ b/query/src/main/java/tech/ydb/query/impl/SessionImpl.java
@@ -182,6 +182,16 @@ abstract class SessionImpl implements QuerySession {
         }
     }
 
+    private String mapPoolId(ExecuteQuerySettings settings) {
+        String actualPoolId = settings.getResourcePool();
+
+        if (actualPoolId == null) {
+            return YdbQuery.ExecuteQueryRequest.getDefaultInstance().getPoolId();
+        }
+
+        return actualPoolId;
+    }
+
     GrpcReadStream<YdbQuery.ExecuteQueryResponsePart> createGrpcStream(
             String query, YdbQuery.TransactionControl tx, Params prms, ExecuteQuerySettings settings
     ) {
@@ -194,7 +204,7 @@ abstract class SessionImpl implements QuerySession {
                         .setText(query)
                         .build()
                 )
-                .setPoolId(settings.getResourcePool())
+                .setPoolId(mapPoolId(settings))
                 .putAllParameters(prms.toPb());
 
         if (tx != null) {

--- a/query/src/main/java/tech/ydb/query/impl/SessionImpl.java
+++ b/query/src/main/java/tech/ydb/query/impl/SessionImpl.java
@@ -194,6 +194,7 @@ abstract class SessionImpl implements QuerySession {
                         .setText(query)
                         .build()
                 )
+                .setPoolId(settings.getResourcePool())
                 .putAllParameters(prms.toPb());
 
         if (tx != null) {

--- a/query/src/main/java/tech/ydb/query/settings/ExecuteQuerySettings.java
+++ b/query/src/main/java/tech/ydb/query/settings/ExecuteQuerySettings.java
@@ -37,7 +37,7 @@ public class ExecuteQuerySettings extends BaseRequestSettings {
     public static class Builder extends BaseBuilder<Builder> {
         private QueryExecMode execMode = QueryExecMode.EXECUTE;
         private QueryStatsMode statsMode = QueryStatsMode.NONE;
-        private String resourcePool = "default";
+        private String resourcePool = null;
 
         public Builder withExecMode(QueryExecMode mode) {
             this.execMode = mode;

--- a/query/src/main/java/tech/ydb/query/settings/ExecuteQuerySettings.java
+++ b/query/src/main/java/tech/ydb/query/settings/ExecuteQuerySettings.java
@@ -9,11 +9,13 @@ import tech.ydb.core.settings.BaseRequestSettings;
 public class ExecuteQuerySettings extends BaseRequestSettings {
     private final QueryExecMode execMode;
     private final QueryStatsMode statsMode;
+    private final String resourcePool;
 
     private ExecuteQuerySettings(Builder builder) {
         super(builder);
         this.execMode = builder.execMode;
         this.statsMode = builder.statsMode;
+        this.resourcePool = builder.resourcePool;
     }
 
     public QueryExecMode getExecMode() {
@@ -24,6 +26,10 @@ public class ExecuteQuerySettings extends BaseRequestSettings {
         return this.statsMode;
     }
 
+    public String getResourcePool() {
+        return this.resourcePool;
+    }
+
     public static Builder newBuilder() {
         return new Builder();
     }
@@ -31,6 +37,7 @@ public class ExecuteQuerySettings extends BaseRequestSettings {
     public static class Builder extends BaseBuilder<Builder> {
         private QueryExecMode execMode = QueryExecMode.EXECUTE;
         private QueryStatsMode statsMode = QueryStatsMode.NONE;
+        private String resourcePool = "default";
 
         public Builder withExecMode(QueryExecMode mode) {
             this.execMode = mode;
@@ -39,6 +46,11 @@ public class ExecuteQuerySettings extends BaseRequestSettings {
 
         public Builder withStatsMode(QueryStatsMode mode) {
             this.statsMode = mode;
+            return this;
+        }
+
+        public Builder withResourcePool(String poolId) {
+            this.resourcePool = poolId;
             return this;
         }
 

--- a/query/src/main/java/tech/ydb/query/settings/ExecuteQuerySettings.java
+++ b/query/src/main/java/tech/ydb/query/settings/ExecuteQuerySettings.java
@@ -9,6 +9,10 @@ import tech.ydb.core.settings.BaseRequestSettings;
 public class ExecuteQuerySettings extends BaseRequestSettings {
     private final QueryExecMode execMode;
     private final QueryStatsMode statsMode;
+
+    /**
+     * Resource pool
+     */
     private final String resourcePool;
 
     private ExecuteQuerySettings(Builder builder) {
@@ -49,6 +53,15 @@ public class ExecuteQuerySettings extends BaseRequestSettings {
             return this;
         }
 
+        /**
+         * Set resource pool which query try to use.
+         * If no pool specify or poolId is empty or poolId equals "default"
+         * the undeleted resource pool "default" wll be used
+         *
+         * @param poolId poolId in ydb
+         *
+         * @return builder
+         */
         public Builder withResourcePool(String poolId) {
             this.resourcePool = poolId;
             return this;

--- a/query/src/test/java/tech/ydb/query/impl/QueryIntegrationResourcePoolTest.java
+++ b/query/src/test/java/tech/ydb/query/impl/QueryIntegrationResourcePoolTest.java
@@ -86,11 +86,32 @@ public class QueryIntegrationResourcePoolTest {
             try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
                 ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
                         .withExecMode(QueryExecMode.EXECUTE)
-                        .withResourcePool("test_pool")
+                        .withResourcePool(TEST_RESOURCE_POOL)
                         .withStatsMode(QueryStatsMode.FULL)
                         .build();
 
                 Assert.assertTrue("Query shouldn't fail",
+                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                                .join().isSuccess());
+            }
+        } finally {
+            deleteResourcePool(TEST_RESOURCE_POOL, true);
+        }
+    }
+
+    @Ignore
+    @Test
+    public void selectWithResourcePoolShouldBeCaseSensitiveTest() {
+        createResourcePool(TEST_RESOURCE_POOL);
+        try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
+                        .withExecMode(QueryExecMode.EXECUTE)
+                        .withResourcePool(TEST_RESOURCE_POOL.toUpperCase())
+                        .withStatsMode(QueryStatsMode.FULL)
+                        .build();
+
+                Assert.assertFalse("Query should fail",
                         session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
                                 .join().isSuccess());
             }

--- a/query/src/test/java/tech/ydb/query/impl/QueryIntegrationResourcePoolTest.java
+++ b/query/src/test/java/tech/ydb/query/impl/QueryIntegrationResourcePoolTest.java
@@ -1,0 +1,180 @@
+package tech.ydb.query.impl;
+
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tech.ydb.common.transaction.TxMode;
+import tech.ydb.core.Issue;
+import tech.ydb.core.Result;
+import tech.ydb.core.Status;
+import tech.ydb.core.StatusCode;
+import tech.ydb.query.QueryClient;
+import tech.ydb.query.QuerySession;
+import tech.ydb.query.QueryStream;
+import tech.ydb.query.QueryTransaction;
+import tech.ydb.query.result.QueryInfo;
+import tech.ydb.query.result.QueryResultPart;
+import tech.ydb.query.settings.ExecuteQuerySettings;
+import tech.ydb.query.settings.QueryExecMode;
+import tech.ydb.query.settings.QueryStatsMode;
+import tech.ydb.query.tools.QueryReader;
+import tech.ydb.table.SessionRetryContext;
+import tech.ydb.table.description.TableDescription;
+import tech.ydb.table.impl.SimpleTableClient;
+import tech.ydb.table.query.Params;
+import tech.ydb.table.result.ResultSetReader;
+import tech.ydb.table.rpc.grpc.GrpcTableRpc;
+import tech.ydb.table.values.PrimitiveType;
+import tech.ydb.table.values.PrimitiveValue;
+import tech.ydb.test.junit4.GrpcTransportRule;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Test on resource poll.
+ * Take an account, that resource poll with name "default" exists every time and can't be deleted
+ * Also when we specify pool with empty string "" it's equivalent to default pool
+ *
+ * @author Evgeny Kuvardin
+ */
+public class QueryIntegrationResourcePoolTest {
+    private final static Logger logger = LoggerFactory.getLogger(QueryIntegrationResourcePoolTest.class);
+    private final static String TEST_TABLE = "query_service_test";
+    private final static String TEST_DOUBLE_TABLE = "query_double_table";
+    private final static String TEST_RESOURCE_POOL = "test_pool";
+
+
+    @ClassRule
+    public final static GrpcTransportRule ydbTransport = new GrpcTransportRule();
+
+    @BeforeClass
+    public static void initSchema() {
+        logger.info("Prepare database...");
+
+        String tablePath = ydbTransport.getDatabase() + "/" + TEST_TABLE;
+        TableDescription tableDescription = TableDescription.newBuilder()
+                .addNonnullColumn("id", PrimitiveType.Int32)
+                .addNullableColumn("name", PrimitiveType.Text)
+                .addNullableColumn("payload", PrimitiveType.Bytes)
+                .addNullableColumn("is_valid", PrimitiveType.Bool)
+                .setPrimaryKey("id")
+                .build();
+
+
+        String table2Path = ydbTransport.getDatabase() + "/" + TEST_DOUBLE_TABLE;
+        TableDescription table2Description = TableDescription.newBuilder()
+                .addNonnullColumn("id", PrimitiveType.Int32)
+                .addNullableColumn("amount", PrimitiveType.Double)
+                .setPrimaryKey("id")
+                .build();
+
+        SimpleTableClient client = SimpleTableClient.newClient(GrpcTableRpc.useTransport(ydbTransport)).build();
+        SessionRetryContext retryCtx = SessionRetryContext.create(client).build();
+        retryCtx.supplyStatus(session -> session.createTable(tablePath, tableDescription)).join();
+        retryCtx.supplyStatus(session -> session.createTable(table2Path, table2Description)).join();
+        logger.info("Prepare database OK");
+
+        try (QueryClient queryClient = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession querySession = queryClient.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                Result<QueryInfo> result = querySession.createQuery("CREATE RESOURCE POOL " + TEST_RESOURCE_POOL + " WITH (\n" +
+                        "    CONCURRENT_QUERY_LIMIT=10,\n" +
+                        "    QUEUE_SIZE=1000,\n" +
+                        "    DATABASE_LOAD_CPU_THRESHOLD=80,\n" +
+                        "    TOTAL_CPU_LIMIT_PERCENT_PER_NODE=70);", TxMode.NONE).execute().join();
+
+                Assert.assertTrue(result.getValue().toString(), result.isSuccess());
+            }
+        }
+    }
+
+    @AfterClass
+    public static void dropAll() {
+        logger.info("Clean database...");
+        String tablePath = ydbTransport.getDatabase() + "/" + TEST_TABLE;
+        String table2Path = ydbTransport.getDatabase() + "/" + TEST_DOUBLE_TABLE;
+
+        SimpleTableClient client = SimpleTableClient.newClient(GrpcTableRpc.useTransport(ydbTransport)).build();
+        SessionRetryContext retryCtx = SessionRetryContext.create(client).build();
+        retryCtx.supplyStatus(session -> session.dropTable(tablePath)).join().isSuccess();
+        retryCtx.supplyStatus(session -> session.dropTable(table2Path)).join().isSuccess();
+
+        try (QueryClient queryClient = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession querySession = queryClient.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                Result<QueryInfo> result = querySession.createQuery("DROP RESOURCE POOL " + TEST_RESOURCE_POOL + ";", TxMode.NONE).execute().join();
+
+                Assert.assertTrue(result.getValue().toString(), result.isSuccess());
+            }
+        }
+
+        logger.info("Clean database OK");
+    }
+
+    @Test
+    public void selectWithResourcePoolTest() {
+        try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
+                        .withExecMode(QueryExecMode.EXECUTE)
+                        .withResourcePool("test_pool")
+                        .build();
+
+                Assert.assertTrue("Query shouldn't fall",
+                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                                .join().isSuccess());
+            }
+        }
+    }
+
+    @Test
+    public void selectWithDefaultResourcePoolTest() {
+        try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
+                        .withExecMode(QueryExecMode.EXECUTE)
+                        .withResourcePool("default")
+                        .build();
+
+                Assert.assertTrue("Query shouldn't fall",
+                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                                .join().isSuccess());
+            }
+        }
+    }
+
+    @Test
+    public void selectWithDefaultResourcePoolAndEmptyStringTest() {
+        try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
+                        .withExecMode(QueryExecMode.EXECUTE)
+                        .withResourcePool("")
+                        .build();
+
+                Assert.assertTrue("Query shouldn't fall",
+                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                                .join().isSuccess());
+            }
+        }
+    }
+
+    @Test
+    public void selectShouldFailWithUnknownResourcePollTest() {
+        try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
+                        .withExecMode(QueryExecMode.EXECUTE)
+                        .withResourcePool("some_unknown_pool")
+                        .build();
+
+                Assert.assertFalse("Query should fall",
+                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                                .join().isSuccess());
+            }
+        }
+    }
+}

--- a/query/src/test/java/tech/ydb/query/impl/QueryIntegrationResourcePoolTest.java
+++ b/query/src/test/java/tech/ydb/query/impl/QueryIntegrationResourcePoolTest.java
@@ -5,48 +5,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import tech.ydb.common.transaction.TxMode;
-import tech.ydb.core.Issue;
 import tech.ydb.core.Result;
-import tech.ydb.core.Status;
-import tech.ydb.core.StatusCode;
 import tech.ydb.query.QueryClient;
 import tech.ydb.query.QuerySession;
-import tech.ydb.query.QueryStream;
-import tech.ydb.query.QueryTransaction;
 import tech.ydb.query.result.QueryInfo;
-import tech.ydb.query.result.QueryResultPart;
 import tech.ydb.query.settings.ExecuteQuerySettings;
 import tech.ydb.query.settings.QueryExecMode;
 import tech.ydb.query.settings.QueryStatsMode;
-import tech.ydb.query.tools.QueryReader;
 import tech.ydb.table.SessionRetryContext;
 import tech.ydb.table.description.TableDescription;
 import tech.ydb.table.impl.SimpleTableClient;
 import tech.ydb.table.query.Params;
-import tech.ydb.table.result.ResultSetReader;
 import tech.ydb.table.rpc.grpc.GrpcTableRpc;
 import tech.ydb.table.values.PrimitiveType;
-import tech.ydb.table.values.PrimitiveValue;
 import tech.ydb.test.junit4.GrpcTransportRule;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Test on resource poll.
+ * <p>
  * Take an account, that resource poll with name "default" exists every time and can't be deleted
  * Also when we specify pool with empty string "" it's equivalent to default pool
+ * <p>
+ * Test marked with @Ignore should be uncommented when resource pool disappeared from experimental feature
+ * <p>
+ * Until this to run test go to @see tech.ydb.test.integration.YdbEnvironment
+ * {@link tech.ydb.test.integration.YdbEnvironment}
+ * dockerFeatures = createParam("YDB_DOCKER_FEATURE_FLAGS", "enable_resource_pools");
+ * By the way feature available with image ydbplatform/local-ydb:24.3.11.13";
  *
  * @author Evgeny Kuvardin
  */
 public class QueryIntegrationResourcePoolTest {
     private final static Logger logger = LoggerFactory.getLogger(QueryIntegrationResourcePoolTest.class);
-    private final static String TEST_TABLE = "query_service_test";
-    private final static String TEST_DOUBLE_TABLE = "query_double_table";
+    private final static String TEST_TABLE = "query_resource_pool_service_test";
     private final static String TEST_RESOURCE_POOL = "test_pool";
+    private final static String TEST_RESOURCE_POOL_WITH_DELETE = "test_pool_fot_delete";
 
 
     @ClassRule
@@ -60,75 +55,81 @@ public class QueryIntegrationResourcePoolTest {
         TableDescription tableDescription = TableDescription.newBuilder()
                 .addNonnullColumn("id", PrimitiveType.Int32)
                 .addNullableColumn("name", PrimitiveType.Text)
-                .addNullableColumn("payload", PrimitiveType.Bytes)
-                .addNullableColumn("is_valid", PrimitiveType.Bool)
-                .setPrimaryKey("id")
-                .build();
-
-
-        String table2Path = ydbTransport.getDatabase() + "/" + TEST_DOUBLE_TABLE;
-        TableDescription table2Description = TableDescription.newBuilder()
-                .addNonnullColumn("id", PrimitiveType.Int32)
-                .addNullableColumn("amount", PrimitiveType.Double)
                 .setPrimaryKey("id")
                 .build();
 
         SimpleTableClient client = SimpleTableClient.newClient(GrpcTableRpc.useTransport(ydbTransport)).build();
         SessionRetryContext retryCtx = SessionRetryContext.create(client).build();
-        retryCtx.supplyStatus(session -> session.createTable(tablePath, tableDescription)).join();
-        retryCtx.supplyStatus(session -> session.createTable(table2Path, table2Description)).join();
+        Assert.assertTrue("Table should be created before tests",
+                retryCtx.supplyStatus(session -> session.createTable(tablePath, tableDescription)).join().isSuccess());
         logger.info("Prepare database OK");
 
-        try (QueryClient queryClient = QueryClient.newClient(ydbTransport).build()) {
-            try (QuerySession querySession = queryClient.createSession(Duration.ofSeconds(5)).join().getValue()) {
-                Result<QueryInfo> result = querySession.createQuery("CREATE RESOURCE POOL " + TEST_RESOURCE_POOL + " WITH (\n" +
-                        "    CONCURRENT_QUERY_LIMIT=10,\n" +
-                        "    QUEUE_SIZE=1000,\n" +
-                        "    DATABASE_LOAD_CPU_THRESHOLD=80,\n" +
-                        "    TOTAL_CPU_LIMIT_PERCENT_PER_NODE=70);", TxMode.NONE).execute().join();
-
-                Assert.assertTrue(result.getValue().toString(), result.isSuccess());
-            }
-        }
     }
 
     @AfterClass
     public static void dropAll() {
         logger.info("Clean database...");
         String tablePath = ydbTransport.getDatabase() + "/" + TEST_TABLE;
-        String table2Path = ydbTransport.getDatabase() + "/" + TEST_DOUBLE_TABLE;
 
         SimpleTableClient client = SimpleTableClient.newClient(GrpcTableRpc.useTransport(ydbTransport)).build();
         SessionRetryContext retryCtx = SessionRetryContext.create(client).build();
-        retryCtx.supplyStatus(session -> session.dropTable(tablePath)).join().isSuccess();
-        retryCtx.supplyStatus(session -> session.dropTable(table2Path)).join().isSuccess();
-
-        try (QueryClient queryClient = QueryClient.newClient(ydbTransport).build()) {
-            try (QuerySession querySession = queryClient.createSession(Duration.ofSeconds(5)).join().getValue()) {
-                Result<QueryInfo> result = querySession.createQuery("DROP RESOURCE POOL " + TEST_RESOURCE_POOL + ";", TxMode.NONE).execute().join();
-
-                Assert.assertTrue(result.getValue().toString(), result.isSuccess());
-            }
-        }
+        retryCtx.supplyStatus(session -> session.dropTable(tablePath)).join();
 
         logger.info("Clean database OK");
     }
 
+    @Ignore
     @Test
     public void selectWithResourcePoolTest() {
+        createResourcePool(TEST_RESOURCE_POOL);
         try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
             try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
                 ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
                         .withExecMode(QueryExecMode.EXECUTE)
                         .withResourcePool("test_pool")
+                        .withStatsMode(QueryStatsMode.FULL)
                         .build();
 
-                Assert.assertTrue("Query shouldn't fall",
-                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                Assert.assertTrue("Query shouldn't fail",
+                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
                                 .join().isSuccess());
             }
+        } finally {
+            deleteResourcePool(TEST_RESOURCE_POOL, true);
         }
     }
+
+    /**
+     * Check that we don't cache resource pool in session
+     */
+    @Ignore
+    @Test
+    public void selectWithResourcePoolShouldNotCachePoolInSessionTest() {
+        createResourcePool(TEST_RESOURCE_POOL_WITH_DELETE);
+
+        try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession session = client.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
+                        .withExecMode(QueryExecMode.EXECUTE)
+                        .withResourcePool(TEST_RESOURCE_POOL_WITH_DELETE)
+                        .withStatsMode(QueryStatsMode.FULL)
+                        .build();
+
+                Assert.assertTrue("Query shouldn't fail",
+                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                                .join().isSuccess());
+
+                deleteResourcePool(TEST_RESOURCE_POOL_WITH_DELETE, true);
+
+                Assert.assertTrue("Query shouldn't cache in session previous call to resource pool",
+                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty()).execute()
+                                .join().isSuccess());
+            }
+        } finally {
+            deleteResourcePool(TEST_RESOURCE_POOL_WITH_DELETE, false);
+        }
+    }
+
 
     @Test
     public void selectWithDefaultResourcePoolTest() {
@@ -137,10 +138,11 @@ public class QueryIntegrationResourcePoolTest {
                 ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
                         .withExecMode(QueryExecMode.EXECUTE)
                         .withResourcePool("default")
+                        .withStatsMode(QueryStatsMode.FULL)
                         .build();
 
-                Assert.assertTrue("Query shouldn't fall",
-                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                Assert.assertTrue("Query shouldn't fail with default pool name",
+                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
                                 .join().isSuccess());
             }
         }
@@ -155,13 +157,14 @@ public class QueryIntegrationResourcePoolTest {
                         .withResourcePool("")
                         .build();
 
-                Assert.assertTrue("Query shouldn't fall",
-                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                Assert.assertTrue("Query shouldn't fail cause empty string equivalent to default pool.",
+                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
                                 .join().isSuccess());
             }
         }
     }
 
+    @Ignore
     @Test
     public void selectShouldFailWithUnknownResourcePollTest() {
         try (QueryClient client = QueryClient.newClient(ydbTransport).build()) {
@@ -169,11 +172,37 @@ public class QueryIntegrationResourcePoolTest {
                 ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
                         .withExecMode(QueryExecMode.EXECUTE)
                         .withResourcePool("some_unknown_pool")
+                        .withStatsMode(QueryStatsMode.FULL)
                         .build();
 
-                Assert.assertFalse("Query should fall",
-                        session.createQuery("SELECT 2 + 3;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
+                Assert.assertFalse("Query should fail cause poll not exists",
+                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute()
                                 .join().isSuccess());
+            }
+        }
+    }
+
+    private static void createResourcePool(String resourcePoolName) {
+        try (QueryClient queryClient = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession querySession = queryClient.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                Result<QueryInfo> result = querySession.createQuery("CREATE RESOURCE POOL " + resourcePoolName + " WITH (\n" +
+                        "    CONCURRENT_QUERY_LIMIT=10,\n" +
+                        "    QUEUE_SIZE=1000,\n" +
+                        "    DATABASE_LOAD_CPU_THRESHOLD=80);", TxMode.NONE).execute().join();
+
+                Assert.assertTrue(result.getStatus().toString(), result.isSuccess());
+            }
+        }
+    }
+
+    private static void deleteResourcePool(String resourcePoolName, boolean checkError) {
+        try (QueryClient queryClient = QueryClient.newClient(ydbTransport).build()) {
+            try (QuerySession querySession = queryClient.createSession(Duration.ofSeconds(5)).join().getValue()) {
+                Result<QueryInfo> result = querySession.createQuery("DROP RESOURCE POOL " + resourcePoolName + ";", TxMode.NONE).execute().join();
+
+                if (checkError) {
+                    Assert.assertTrue(result.getStatus().toString(), result.isSuccess());
+                }
             }
         }
     }

--- a/query/src/test/java/tech/ydb/query/impl/SessionImplTest.java
+++ b/query/src/test/java/tech/ydb/query/impl/SessionImplTest.java
@@ -1,4 +1,0 @@
-package tech.ydb.query.impl;
-
-public class SessionImplTest {
-}

--- a/query/src/test/java/tech/ydb/query/impl/SessionImplTest.java
+++ b/query/src/test/java/tech/ydb/query/impl/SessionImplTest.java
@@ -1,0 +1,4 @@
+package tech.ydb.query.impl;
+
+public class SessionImplTest {
+}


### PR DESCRIPTION
Connected to https://github.com/ydb-platform/ydb-java-sdk/issues/335


**Checkstyle**
I couldn't find any checkstyle in projects and use default idea checkstyle.
Please give a link if you have one.

**Solution**

Try to make codestyle like in go https://github.com/ydb-platform/ydb-go-sdk/issues/1519 
ExecuteQuerySettings finally looks like

```
 ExecuteQuerySettings settings = ExecuteQuerySettings.newBuilder()
                        .withExecMode(QueryExecMode.EXECUTE)
                        .withResourcePool(TEST_RESOURCE_POOL_WITH_DELETE)
                        .withStatsMode(QueryStatsMode.FULL)
                        .build();
```

QuerySession doesn't changed and looks like this
```

 ExecuteQuerySettings settings = ....

                        session.createQuery("SELECT id, name FROM " + TEST_TABLE + " ORDER BY id;", TxMode.SERIALIZABLE_RW, Params.empty(), settings).execute().join();
```

**Doubts**
Take a look at TableClientImpl method executeDataQueryInternal code

```
        @Override
        public CompletableFuture<Result<DataQueryResult>> executeDataQueryInternal(
                String query, YdbTable.TransactionControl tx, Params prms, ExecuteDataQuerySettings settings) {
            YdbQuery.TransactionControl tc = mapTxControl(tx);
            ExecuteQuerySettings qs = ExecuteQuerySettings.newBuilder()
                    .withTraceId(settings.getTraceId())
                    .withRequestTimeout(settings.getTimeoutDuration())
                    .build();

            final AtomicReference<String> txRef = new AtomicReference<>("");
            QueryStream stream = querySession.new StreamImpl(querySession.createGrpcStream(query, tc, prms, qs)) {
```
           
In this code ExecuteQuerySettings don't use withResourcePool at all.
May be add withResourcePool in ExecuteDataQuerySettings?

**Test**
Also write some integration test.
All tests connected to Resource Pool I carried out in another class QueryIntegrationResourcePoolTest
For me it's better have different class for some features than have one big class with all test connected to Query.
Each feature needs some additional objects and checks specified for the feature but not the whole tests.

**Some test problems**
***Problem with feature***
In "ydbplatform/local-ydb:latest" you have to enable in tech.ydb.test.integration.YdbEnvironment
dockerFeatures = createParam("YDB_DOCKER_FEATURE_FLAGS", "enable_resource_pools"); to run test with pool
More detail I write in QueryIntegrationResourcePoolTest

I divide the test into 2 groups.
The first one passes, ignoring enable_resource_pools.
The second one runs only with enable_resource_pools -> I marked it as ignored. This annotation may be removed after the resource pool is enabled and removed from the experimental feature.

***Test depending on feature***
Some test give results depending on the enabled/disabled feature enable_resource_pools.
Take a look at QueryIntegrationResourcePoolTest.selectShouldFailWithUnknownResourcePollTest

When enable_resource_pools = true
select with unknown pool failed

When enable_resource_pools = false
select with unknown pool doesn't failed

I marked it as Ignore and will be enabled after enable_resource_pools = true

**Some thoughts**
Maybe just wait when the resource pool is removed from the experimental feature and becomes available in "ydbplatform/local-ydb:latest." after that merged in master. Then we can easily remove the annotation Ignore. Your repository, your call. 

**Ydb Image tested**
24.3.11.13
24.4
24.4.4
24.5.1

**Java tested**
Java openjdk 21
Java openjdk 11




