### PR TITLE
Add equals() and hashCode() methods to topic description classes

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/description/Consumer.java
+++ b/topic/src/main/java/tech/ydb/topic/description/Consumer.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -139,5 +140,24 @@ public class Consumer {
             }
             return new Consumer(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Consumer consumer = (Consumer) o;
+        return important == consumer.important &&
+                Objects.equals(name, consumer.name) &&
+                Objects.equals(readFrom, consumer.readFrom) &&
+                Objects.equals(supportedCodecs, consumer.supportedCodecs) &&
+                Objects.equals(attributes, consumer.attributes) &&
+                Objects.equals(stats, consumer.stats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, important, readFrom, supportedCodecs, attributes, stats);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/ConsumerDescription.java
+++ b/topic/src/main/java/tech/ydb/topic/description/ConsumerDescription.java
@@ -2,6 +2,7 @@ package tech.ydb.topic.description;
 
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import tech.ydb.proto.topic.YdbTopic;
@@ -27,5 +28,19 @@ public class ConsumerDescription {
 
     public List<ConsumerPartitionInfo> getPartitions() {
         return partitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsumerDescription that = (ConsumerDescription) o;
+        return Objects.equals(consumer, that.consumer) && Objects.equals(partitions, that.partitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(consumer, partitions);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/ConsumerPartitionInfo.java
+++ b/topic/src/main/java/tech/ydb/topic/description/ConsumerPartitionInfo.java
@@ -3,6 +3,7 @@ package tech.ydb.topic.description;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 
 import tech.ydb.core.utils.ProtobufUtils;
 import tech.ydb.proto.topic.YdbTopic;
@@ -177,5 +178,33 @@ public class ConsumerPartitionInfo {
         public int getConnectionNodeId() {
             return connectionNodeId;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsumerPartitionInfo that = (ConsumerPartitionInfo) o;
+        return partitionId == that.partitionId &&
+                active == that.active &&
+                Objects.equals(childPartitionIds, that.childPartitionIds) &&
+                Objects.equals(parentPartitionIds, that.parentPartitionIds) &&
+                Objects.equals(partitionStats, that.partitionStats) &&
+                Objects.equals(consumerStats, that.consumerStats) &&
+                Objects.equals(location, that.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                partitionId,
+                active,
+                childPartitionIds,
+                parentPartitionIds,
+                partitionStats,
+                consumerStats,
+                location
+        );
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/MultipleWindowsStat.java
+++ b/topic/src/main/java/tech/ydb/topic/description/MultipleWindowsStat.java
@@ -1,5 +1,7 @@
 package tech.ydb.topic.description;
 
+import java.util.Objects;
+
 import tech.ydb.proto.topic.YdbTopic;
 
 /**
@@ -32,5 +34,19 @@ public class MultipleWindowsStat {
 
     public long getPerDay() {
         return perDay;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MultipleWindowsStat that = (MultipleWindowsStat) o;
+        return perMinute == that.perMinute && perHour == that.perHour && perDay == that.perDay;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(perMinute, perHour, perDay);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/PartitionInfo.java
+++ b/topic/src/main/java/tech/ydb/topic/description/PartitionInfo.java
@@ -2,6 +2,7 @@ package tech.ydb.topic.description;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.google.common.collect.ImmutableList;
 
@@ -85,5 +86,23 @@ public class PartitionInfo {
         public PartitionInfo build() {
             return new PartitionInfo(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PartitionInfo that = (PartitionInfo) o;
+        return partitionId == that.partitionId &&
+                active == that.active &&
+                Objects.equals(childPartitionIds, that.childPartitionIds) &&
+                Objects.equals(parentPartitionIds, that.parentPartitionIds) &&
+                Objects.equals(partitionStats, that.partitionStats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionId, active, childPartitionIds, parentPartitionIds, partitionStats);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/PartitionStats.java
+++ b/topic/src/main/java/tech/ydb/topic/description/PartitionStats.java
@@ -2,6 +2,7 @@ package tech.ydb.topic.description;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -125,5 +126,31 @@ public class PartitionStats {
         public PartitionStats build() {
             return new PartitionStats(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PartitionStats that = (PartitionStats) o;
+        return storeSizeBytes == that.storeSizeBytes &&
+                partitionNodeId == that.partitionNodeId &&
+                Objects.equals(partitionOffsets, that.partitionOffsets) &&
+                Objects.equals(lastWriteTime, that.lastWriteTime) &&
+                Objects.equals(maxWriteTimeLag, that.maxWriteTimeLag) &&
+                Objects.equals(bytesWritten, that.bytesWritten);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                partitionOffsets,
+                storeSizeBytes,
+                lastWriteTime,
+                maxWriteTimeLag,
+                bytesWritten,
+                partitionNodeId
+        );
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/SupportedCodecs.java
+++ b/topic/src/main/java/tech/ydb/topic/description/SupportedCodecs.java
@@ -2,6 +2,7 @@ package tech.ydb.topic.description;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.google.common.collect.ImmutableList;
 
@@ -46,5 +47,19 @@ public class SupportedCodecs {
         public SupportedCodecs build() {
             return new SupportedCodecs(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SupportedCodecs that = (SupportedCodecs) o;
+        return Objects.equals(codecs, that.codecs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(codecs);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/TopicDescription.java
+++ b/topic/src/main/java/tech/ydb/topic/description/TopicDescription.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -178,5 +179,41 @@ public class TopicDescription {
         public TopicDescription build() {
             return new TopicDescription(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopicDescription that = (TopicDescription) o;
+        return retentionStorageMb == that.retentionStorageMb &&
+                partitionWriteSpeedBytesPerSecond == that.partitionWriteSpeedBytesPerSecond &&
+                partitionWriteBurstBytes == that.partitionWriteBurstBytes &&
+                Objects.equals(partitioningSettings, that.partitioningSettings) &&
+                Objects.equals(partitions, that.partitions) &&
+                Objects.equals(retentionPeriod, that.retentionPeriod) &&
+                Objects.equals(supportedCodecs, that.supportedCodecs) &&
+                Objects.equals(attributes, that.attributes) &&
+                Objects.equals(consumers, that.consumers) &&
+                meteringMode == that.meteringMode &&
+                Objects.equals(topicStats, that.topicStats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                partitioningSettings,
+                partitions,
+                retentionPeriod,
+                retentionStorageMb,
+                supportedCodecs,
+                partitionWriteSpeedBytesPerSecond,
+                partitionWriteBurstBytes,
+                attributes,
+                consumers,
+                meteringMode,
+                topicStats
+        );
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/description/TopicStats.java
+++ b/topic/src/main/java/tech/ydb/topic/description/TopicStats.java
@@ -2,6 +2,7 @@ package tech.ydb.topic.description;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -75,5 +76,22 @@ public class TopicStats {
         public TopicStats build() {
             return new TopicStats(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopicStats that = (TopicStats) o;
+        return storeSizeBytes == that.storeSizeBytes &&
+                Objects.equals(minLastWriteTime, that.minLastWriteTime) &&
+                Objects.equals(maxWriteTimeLag, that.maxWriteTimeLag) &&
+                Objects.equals(bytesWritten, that.bytesWritten);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(storeSizeBytes, minLastWriteTime, maxWriteTimeLag, bytesWritten);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/read/impl/OffsetsRangeImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/OffsetsRangeImpl.java
@@ -1,5 +1,7 @@
 package tech.ydb.topic.read.impl;
 
+import java.util.Objects;
+
 import tech.ydb.topic.description.OffsetsRange;
 
 /**
@@ -35,5 +37,19 @@ public class OffsetsRangeImpl implements OffsetsRange {
 
     public void setEnd(long end) {
         this.end = end;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OffsetsRangeImpl that = (OffsetsRangeImpl) o;
+        return start == that.start && end == that.end;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/settings/AutoPartitioningWriteStrategySettings.java
+++ b/topic/src/main/java/tech/ydb/topic/settings/AutoPartitioningWriteStrategySettings.java
@@ -1,6 +1,7 @@
 package tech.ydb.topic.settings;
 
 import java.time.Duration;
+import java.util.Objects;
 
 public class AutoPartitioningWriteStrategySettings {
     private final Duration stabilizationWindow;
@@ -68,5 +69,21 @@ public class AutoPartitioningWriteStrategySettings {
         public AutoPartitioningWriteStrategySettings build() {
             return new AutoPartitioningWriteStrategySettings(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AutoPartitioningWriteStrategySettings that = (AutoPartitioningWriteStrategySettings) o;
+        return upUtilizationPercent == that.upUtilizationPercent &&
+                downUtilizationPercent == that.downUtilizationPercent &&
+                Objects.equals(stabilizationWindow, that.stabilizationWindow);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stabilizationWindow, upUtilizationPercent, downUtilizationPercent);
     }
 }

--- a/topic/src/main/java/tech/ydb/topic/settings/PartitioningSettings.java
+++ b/topic/src/main/java/tech/ydb/topic/settings/PartitioningSettings.java
@@ -1,5 +1,7 @@
 package tech.ydb.topic.settings;
 
+import java.util.Objects;
+
 /**
  * @author Nikolay Perfilov
  */
@@ -106,5 +108,22 @@ public class PartitioningSettings {
         public PartitioningSettings build() {
             return new PartitioningSettings(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PartitioningSettings that = (PartitioningSettings) o;
+        return minActivePartitions == that.minActivePartitions &&
+                partitionCountLimit == that.partitionCountLimit &&
+                autoPartitioningStrategy == that.autoPartitioningStrategy &&
+                Objects.equals(writeStrategySettings, that.writeStrategySettings);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minActivePartitions, partitionCountLimit, autoPartitioningStrategy, writeStrategySettings);
     }
 }


### PR DESCRIPTION
This PR introduces proper equals() and hashCode() implementations to classes used during topic description operations. These implementations follow standard Java equality contract patterns and allow for reliable comparison of description objects.