### PR TITLE
SyncWriter.flush() now throw Exception when previous task was failed

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -276,9 +276,7 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
         incomingQueueLock.lock();
 
         try {
-            return this.lastAcceptedMessageFuture.isDone()
-                    ? CompletableFuture.completedFuture(null)
-                    : this.lastAcceptedMessageFuture.thenApply(v -> null);
+            return this.lastAcceptedMessageFuture.thenApply(v -> null);
         } finally {
             incomingQueueLock.unlock();
         }

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriterImpl.java
@@ -269,6 +269,11 @@ public abstract class WriterImpl extends GrpcStreamRetrier {
         return tryToEnqueue(enqueuedMessage, instant).thenApply(v -> enqueuedMessage.getFuture());
     }
 
+    /**
+     * Create a wrapper upon the future for the flush method.
+     *
+     * @return an empty Future if successful. Throw CompletionException when an error occurs.
+     */
     protected CompletableFuture<Void> flushImpl() {
         if (this.lastAcceptedMessageFuture == null) {
             return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
Problem connected to this one https://github.com/ydb-platform/ydb-java-sdk/issues/475

**What's the cause?**

A problem when encoding/decoding (or something else) throws an error.

The user writes
```
WriterSettings settings = WriterSettings.newBuilder()
                .setTopicPath(topicName)
                .setCodec(10000) // or .setCodec(Codec.CUSTOM) for new version
                .build();
        SyncWriter writer = client.createSyncWriter(settings);
         writer.initAndWait();


        for (byte[] testMessage : testMessages) {
            writer.send(Message.newBuilder().setData(testMessage).build());
        }

       writer.flush();
       writer.shutdown(1, TimeUnit.MINUTES);
```

Code in writer.send failed because codec CUSTOM did not exist.
But the problem is _when_ it's failed before or writer.flush(); 

When we call writer.flush(), we finally end up in flushImpl.
Take a look at in WriterImpl
```
this.lastAcceptedMessageFuture.isDone()
                    ? CompletableFuture.completedFuture(null)
                    : this.lastAcceptedMessageFuture.thenApply(v -> null);
```
If the thread was too quick, then lastAcceptedMessageFuture - DONE(with error inside future), we return CompletableFuture.completedFuture(null) and writer.flush() doesn't fail.

If the thread is slow, then lastAcceptedMessageFuture is NOT COMPLETED, and we call  lastAcceptedMessageFuture.thenApply(v -> null) and failed with RuntimeException wraped  by CompletionException 

Behavior depends on the speed of the test/machine and so on.

**Solution**
I think that we should throw an error in writer.flush()
Return his. lastAcceptedMessageFuture.thenApply(v -> null); despite whether lastAcceptedMessageFuture is done or not

**Test**

A bit confused where to write the test.
Test depends on https://github.com/ydb-platform/ydb-java-sdk/pull/447 (Codec class)

Also, in MR below, we can uncomment Ignore test in YdbTopicsCodecIntegrationTest they will pass.
Maybe wait for MR to push?
On the other hand I can write simple one test -> just push Thread.sleep(5000) before  writer.flush();

