### PR TITLE
405.describe table options

### DIFF
--- a/table/src/main/java/tech/ydb/table/Session.java
+++ b/table/src/main/java/tech/ydb/table/Session.java
@@ -91,10 +91,10 @@ public interface Session extends AutoCloseable {
     CompletableFuture<Result<ExplainDataQueryResult>> explainDataQuery(String query, ExplainDataQuerySettings settings);
 
     /**
-     * Get global table options settings
+     * Get table option settings
      *
      * @param settings settings
-     * @return global table options settings
+     * @return fully described options settings
      */
     CompletableFuture<Result<TableOptionDescription>> describeTableOptions(DescribeTableOptionsSettings settings);
 
@@ -233,7 +233,7 @@ public interface Session extends AutoCloseable {
     }
 
     /**
-     * Get table option settings
+     * Get table option settings with default {@link DescribeTableOptionsSettings}
      *
      * @return fully described options settings
      */

--- a/table/src/main/java/tech/ydb/table/Session.java
+++ b/table/src/main/java/tech/ydb/table/Session.java
@@ -11,6 +11,7 @@ import tech.ydb.core.Status;
 import tech.ydb.core.grpc.GrpcReadStream;
 import tech.ydb.core.impl.call.ProxyReadStream;
 import tech.ydb.table.description.TableDescription;
+import tech.ydb.table.description.TableOptionDescription;
 import tech.ydb.table.query.DataQuery;
 import tech.ydb.table.query.DataQueryResult;
 import tech.ydb.table.query.ExplainDataQueryResult;
@@ -25,6 +26,7 @@ import tech.ydb.table.settings.CommitTxSettings;
 import tech.ydb.table.settings.CopyTableSettings;
 import tech.ydb.table.settings.CopyTablesSettings;
 import tech.ydb.table.settings.CreateTableSettings;
+import tech.ydb.table.settings.DescribeTableOptionsSettings;
 import tech.ydb.table.settings.DescribeTableSettings;
 import tech.ydb.table.settings.DropTableSettings;
 import tech.ydb.table.settings.ExecuteDataQuerySettings;
@@ -87,6 +89,8 @@ public interface Session extends AutoCloseable {
     CompletableFuture<Status> executeSchemeQuery(String query, ExecuteSchemeQuerySettings settings);
 
     CompletableFuture<Result<ExplainDataQueryResult>> explainDataQuery(String query, ExplainDataQuerySettings settings);
+
+    CompletableFuture<Result<TableOptionDescription>> describeTableOptions(DescribeTableOptionsSettings settings);
 
     /**
      * Consider using {@link Session#beginTransaction(TxMode, BeginTxSettings)} instead
@@ -220,6 +224,10 @@ public interface Session extends AutoCloseable {
 
     default CompletableFuture<Status> executeBulkUpsert(String tablePath, ListValue rows) {
         return executeBulkUpsert(tablePath, rows, new BulkUpsertSettings());
+    }
+
+    default CompletableFuture<Result<TableOptionDescription>> describeTableOptions() {
+        return describeTableOptions(new DescribeTableOptionsSettings());
     }
 
     default CompletableFuture<Result<State>> keepAlive() {

--- a/table/src/main/java/tech/ydb/table/Session.java
+++ b/table/src/main/java/tech/ydb/table/Session.java
@@ -90,6 +90,12 @@ public interface Session extends AutoCloseable {
 
     CompletableFuture<Result<ExplainDataQueryResult>> explainDataQuery(String query, ExplainDataQuerySettings settings);
 
+    /**
+     * Get global table options settings
+     *
+     * @param settings settings
+     * @return global table options settings
+     */
     CompletableFuture<Result<TableOptionDescription>> describeTableOptions(DescribeTableOptionsSettings settings);
 
     /**
@@ -226,6 +232,11 @@ public interface Session extends AutoCloseable {
         return executeBulkUpsert(tablePath, rows, new BulkUpsertSettings());
     }
 
+    /**
+     * Get table option settings
+     *
+     * @return fully described options settings
+     */
     default CompletableFuture<Result<TableOptionDescription>> describeTableOptions() {
         return describeTableOptions(new DescribeTableOptionsSettings());
     }

--- a/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
+++ b/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
@@ -75,10 +75,6 @@ public class TableOptionDescription {
         private List<ReplicationPolicyDescription> replicationPolicyPresets;
         private List<CachingPolicyDescription> cachingPolicyPresets;
 
-        public List<TableProfileDescription> getTableProfileDescriptions() {
-            return tableProfileDescriptions;
-        }
-
         public void setTableProfileDescriptions(List<TableProfileDescription> tableProfileDescriptions) {
             this.tableProfileDescriptions = tableProfileDescriptions;
         }

--- a/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
+++ b/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
@@ -1,0 +1,412 @@
+package tech.ydb.table.description;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TableOptionDescription {
+
+    private final List<TableProfileDescription> tableProfileDescriptions;
+    private final List<StoragePolicyDescription> storagePolicyPresets;
+    private final List<CompactionPolicyDescription> compactionPolicyPresets;
+    private final List<PartitioningPolicyDescription> partitioningPolicyPresets;
+    private final List<ExecutionPolicyDescription> executionPolicyPresets;
+    private final List<ReplicationPolicyDescription> replicationPolicyPresets;
+    private final List<CachingPolicyDescription> cachingPolicyPresets;
+
+    public TableOptionDescription(Builder builder) {
+        this.tableProfileDescriptions = builder.tableProfileDescriptions;
+        this.storagePolicyPresets = builder.storagePolicyPresets;
+        this.compactionPolicyPresets = builder.compactionPolicyPresets;
+        this.partitioningPolicyPresets = builder.partitioningPolicyPresets;
+        this.executionPolicyPresets = builder.executionPolicyPresets;
+        this.replicationPolicyPresets = builder.replicationPolicyPresets;
+        this.cachingPolicyPresets = builder.cachingPolicyPresets;
+    }
+
+    public static TableOptionDescription.Builder newBuilder() {
+        return new TableOptionDescription.Builder();
+    }
+
+    public List<TableProfileDescription> getTableProfileDescriptions() {
+        return tableProfileDescriptions;
+    }
+
+    public List<StoragePolicyDescription> getStoragePolicyPresets() {
+        return storagePolicyPresets;
+    }
+
+    public List<CompactionPolicyDescription> getCompactionPolicyPresets() {
+        return compactionPolicyPresets;
+    }
+
+    public List<PartitioningPolicyDescription> getPartitioningPolicyPresets() {
+        return partitioningPolicyPresets;
+    }
+
+    public List<ExecutionPolicyDescription> getExecutionPolicyPresets() {
+        return executionPolicyPresets;
+    }
+
+    public List<ReplicationPolicyDescription> getReplicationPolicyPresets() {
+        return replicationPolicyPresets;
+    }
+
+    public List<CachingPolicyDescription> getCachingPolicyPresets() {
+        return cachingPolicyPresets;
+    }
+
+    public static class Builder {
+        private List<TableProfileDescription> tableProfileDescriptions;
+        private List<StoragePolicyDescription> storagePolicyPresets;
+        private List<CompactionPolicyDescription> compactionPolicyPresets;
+        private List<PartitioningPolicyDescription> partitioningPolicyPresets;
+        private List<ExecutionPolicyDescription> executionPolicyPresets;
+        private List<ReplicationPolicyDescription> replicationPolicyPresets;
+        private List<CachingPolicyDescription> cachingPolicyPresets;
+
+        public List<TableProfileDescription> getTableProfileDescriptions() {
+            return tableProfileDescriptions;
+        }
+
+        public void setTableProfileDescriptions(ArrayList<TableProfileDescription> tableProfileDescriptions) {
+            this.tableProfileDescriptions = tableProfileDescriptions;
+        }
+
+        public List<StoragePolicyDescription> getStoragePolicyPresets() {
+            return storagePolicyPresets;
+        }
+
+        public void setStoragePolicyPresets(List<StoragePolicyDescription> storagePolicyPresets) {
+            this.storagePolicyPresets = storagePolicyPresets;
+        }
+
+        public List<CompactionPolicyDescription> getCompactionPolicyPresets() {
+            return compactionPolicyPresets;
+        }
+
+        public void setCompactionPolicyPresets(List<CompactionPolicyDescription> compactionPolicyPresets) {
+            this.compactionPolicyPresets = compactionPolicyPresets;
+        }
+
+        public List<PartitioningPolicyDescription> getPartitioningPolicyPresets() {
+            return partitioningPolicyPresets;
+        }
+
+        public void setPartitioningPolicyPresets(List<PartitioningPolicyDescription> partitioningPolicyPresets) {
+            this.partitioningPolicyPresets = partitioningPolicyPresets;
+        }
+
+        public List<ExecutionPolicyDescription> getExecutionPolicyPresets() {
+            return executionPolicyPresets;
+        }
+
+        public void setExecutionPolicyPresets(List<ExecutionPolicyDescription> executionPolicyPresets) {
+            this.executionPolicyPresets = executionPolicyPresets;
+        }
+
+        public List<ReplicationPolicyDescription> getReplicationPolicyPresets() {
+            return replicationPolicyPresets;
+        }
+
+        public void setReplicationPolicyPresets(List<ReplicationPolicyDescription> replicationPolicyPresets) {
+            this.replicationPolicyPresets = replicationPolicyPresets;
+        }
+
+        public List<CachingPolicyDescription> getCachingPolicyPresets() {
+            return cachingPolicyPresets;
+        }
+
+        public void setCachingPolicyPresets(List<CachingPolicyDescription> cachingPolicyPresets) {
+            this.cachingPolicyPresets = cachingPolicyPresets;
+        }
+    }
+
+    public static class TableProfileDescription {
+        private final String name;
+        private final Map<String, String> labels;
+
+        private final String defaultStoragePolicy;
+        private final String defaultCompactionPolicy;
+        private final String defaultPartitioningPolicy;
+        private final String defaultExecutionPolicy;
+        private final String defaultReplicationPolicy;
+        private final String defaultCachingPolicy;
+
+        private final List<String> allowedStoragePolicy;
+        private final List<String> allowedCompactionPolicy;
+        private final List<String> allowedPartitioningPolicy;
+        private final List<String> allowedExecutionPolicy;
+        private final List<String> allowedReplicationPolicy;
+        private final List<String> allowedCachingPolicy;
+
+        public TableProfileDescription(Builder builder) {
+            this.name = builder.name;
+            this.labels = ImmutableMap.copyOf(builder.labels);
+            this.defaultStoragePolicy = builder.defaultStoragePolicy;
+            this.defaultCompactionPolicy = builder.defaultCompactionPolicy;
+            this.defaultPartitioningPolicy = builder.defaultPartitioningPolicy;
+            this.defaultExecutionPolicy = builder.defaultExecutionPolicy;
+            this.defaultReplicationPolicy = builder.defaultReplicationPolicy;
+            this.defaultCachingPolicy = builder.defaultCachingPolicy;
+
+            this.allowedStoragePolicy = ImmutableList.copyOf(builder.allowedStoragePolicy);
+            this.allowedCompactionPolicy = ImmutableList.copyOf(builder.allowedCompactionPolicy);
+            this.allowedPartitioningPolicy = ImmutableList.copyOf(builder.allowedPartitioningPolicy);
+            this.allowedExecutionPolicy = ImmutableList.copyOf(builder.allowedExecutionPolicy);
+            this.allowedReplicationPolicy = ImmutableList.copyOf(builder.allowedReplicationPolicy);
+            this.allowedCachingPolicy = ImmutableList.copyOf(builder.allowedCachingPolicy);
+        }
+
+        public static TableProfileDescription.Builder newBuilder() {
+            return new TableProfileDescription.Builder();
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+
+        public String getDefaultStoragePolicy() {
+            return defaultStoragePolicy;
+        }
+
+        public String getDefaultCompactionPolicy() {
+            return defaultCompactionPolicy;
+        }
+
+        public String getDefaultPartitioningPolicy() {
+            return defaultPartitioningPolicy;
+        }
+
+        public String getDefaultExecutionPolicy() {
+            return defaultExecutionPolicy;
+        }
+
+        public String getDefaultReplicationPolicy() {
+            return defaultReplicationPolicy;
+        }
+
+        public String getDefaultCachingPolicy() {
+            return defaultCachingPolicy;
+        }
+
+        public List<String> getAllowedStoragePolicy() {
+            return allowedStoragePolicy;
+        }
+
+        public List<String> getAllowedCompactionPolicy() {
+            return allowedCompactionPolicy;
+        }
+
+        public List<String> getAllowedPartitioningPolicy() {
+            return allowedPartitioningPolicy;
+        }
+
+        public List<String> getAllowedExecutionPolicy() {
+            return allowedExecutionPolicy;
+        }
+
+        public List<String> getAllowedReplicationPolicy() {
+            return allowedReplicationPolicy;
+        }
+
+        public List<String> getAllowedCachingPolicy() {
+            return allowedCachingPolicy;
+        }
+
+        public static class Builder {
+            String name;
+            Map<String, String> labels;
+
+            String defaultStoragePolicy;
+            String defaultCompactionPolicy;
+            String defaultPartitioningPolicy;
+            String defaultExecutionPolicy;
+            String defaultReplicationPolicy;
+            String defaultCachingPolicy;
+
+            List<String> allowedStoragePolicy;
+            List<String> allowedCompactionPolicy;
+            List<String> allowedPartitioningPolicy;
+            List<String> allowedExecutionPolicy;
+            List<String> allowedReplicationPolicy;
+            List<String> allowedCachingPolicy;
+
+            public TableProfileDescription build() {
+                return new TableProfileDescription(this);
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public void setLabels(Map<String, String> labels) {
+                this.labels = labels;
+            }
+
+            public void setDefaultStoragePolicy(String defaultStoragePolicy) {
+                this.defaultStoragePolicy = defaultStoragePolicy;
+            }
+
+            public void setDefaultCompactionPolicy(String defaultCompactionPolicy) {
+                this.defaultCompactionPolicy = defaultCompactionPolicy;
+            }
+
+            public void setDefaultPartitioningPolicy(String defaultPartitioningPolicy) {
+                this.defaultPartitioningPolicy = defaultPartitioningPolicy;
+            }
+
+            public void setDefaultExecutionPolicy(String defaultExecutionPolicy) {
+                this.defaultExecutionPolicy = defaultExecutionPolicy;
+            }
+
+            public void setDefaultReplicationPolicy(String defaultReplicationPolicy) {
+                this.defaultReplicationPolicy = defaultReplicationPolicy;
+            }
+
+            public void setDefaultCachingPolicy(String defaultCachingPolicy) {
+                this.defaultCachingPolicy = defaultCachingPolicy;
+            }
+
+            public void setAllowedStoragePolicy(List<String> allowedStoragePolicy) {
+                this.allowedStoragePolicy = allowedStoragePolicy;
+            }
+
+            public void setAllowedCompactionPolicy(List<String> allowedCompactionPolicy) {
+                this.allowedCompactionPolicy = allowedCompactionPolicy;
+            }
+
+            public void setAllowedPartitioningPolicy(List<String> allowedPartitioningPolicy) {
+                this.allowedPartitioningPolicy = allowedPartitioningPolicy;
+            }
+
+            public void setAllowedExecutionPolicy(List<String> allowedExecutionPolicy) {
+                this.allowedExecutionPolicy = allowedExecutionPolicy;
+            }
+
+            public void setAllowedReplicationPolicy(List<String> allowedReplicationPolicy) {
+                this.allowedReplicationPolicy = allowedReplicationPolicy;
+            }
+
+            public void setAllowedCachingPolicy(List<String> allowedCachingPolicy) {
+                this.allowedCachingPolicy = allowedCachingPolicy;
+            }
+
+        }
+    }
+
+    public static class StoragePolicyDescription {
+        private final String name;
+        private final Map<String,String> labels;
+
+        public StoragePolicyDescription(String name, Map<String, String> labels) {
+            this.name = name;
+            this.labels = labels;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+    }
+
+    public static class CompactionPolicyDescription {
+        private final String name;
+        private final Map<String,String> labels;
+
+        public CompactionPolicyDescription(String name, Map<String, String> labels) {
+            this.name = name;
+            this.labels = labels;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+    }
+
+    public static class PartitioningPolicyDescription {
+        private final String name;
+        private final Map<String,String> labels;
+
+        public PartitioningPolicyDescription(String name, Map<String, String> labels) {
+            this.name = name;
+            this.labels = labels;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+    }
+
+    public static class ExecutionPolicyDescription {
+        private final String name;
+        private final Map<String,String> labels;
+
+        public ExecutionPolicyDescription(String name, Map<String, String> labels) {
+            this.name = name;
+            this.labels = labels;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+    }
+
+    public static class ReplicationPolicyDescription {
+        private final String name;
+        private final Map<String,String> labels;
+
+        public ReplicationPolicyDescription(String name, Map<String, String> labels) {
+            this.name = name;
+            this.labels = labels;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+    }
+
+    public static class CachingPolicyDescription {
+        private final String name;
+        private final Map<String,String> labels;
+
+        public CachingPolicyDescription(String name, Map<String, String> labels) {
+            this.name = name;
+            this.labels = labels;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+    }
+}

--- a/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
+++ b/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
@@ -1,6 +1,5 @@
 package tech.ydb.table.description;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -80,7 +79,7 @@ public class TableOptionDescription {
             return tableProfileDescriptions;
         }
 
-        public void setTableProfileDescriptions(ArrayList<TableProfileDescription> tableProfileDescriptions) {
+        public void setTableProfileDescriptions(List<TableProfileDescription> tableProfileDescriptions) {
             this.tableProfileDescriptions = tableProfileDescriptions;
         }
 

--- a/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
+++ b/table/src/main/java/tech/ydb/table/description/TableOptionDescription.java
@@ -1,12 +1,17 @@
 package tech.ydb.table.description;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Description of table options which is set globally in YDB
+ *
+ *  @author Evgeny Kuvardin
+ */
 public class TableOptionDescription {
 
     private final List<TableProfileDescription> tableProfileDescriptions;
@@ -59,6 +64,9 @@ public class TableOptionDescription {
         return cachingPolicyPresets;
     }
 
+    /**
+     * Builder to construct {@link TableOptionDescription}
+     */
     public static class Builder {
         private List<TableProfileDescription> tableProfileDescriptions;
         private List<StoragePolicyDescription> storagePolicyPresets;
@@ -76,48 +84,24 @@ public class TableOptionDescription {
             this.tableProfileDescriptions = tableProfileDescriptions;
         }
 
-        public List<StoragePolicyDescription> getStoragePolicyPresets() {
-            return storagePolicyPresets;
-        }
-
         public void setStoragePolicyPresets(List<StoragePolicyDescription> storagePolicyPresets) {
             this.storagePolicyPresets = storagePolicyPresets;
-        }
-
-        public List<CompactionPolicyDescription> getCompactionPolicyPresets() {
-            return compactionPolicyPresets;
         }
 
         public void setCompactionPolicyPresets(List<CompactionPolicyDescription> compactionPolicyPresets) {
             this.compactionPolicyPresets = compactionPolicyPresets;
         }
 
-        public List<PartitioningPolicyDescription> getPartitioningPolicyPresets() {
-            return partitioningPolicyPresets;
-        }
-
         public void setPartitioningPolicyPresets(List<PartitioningPolicyDescription> partitioningPolicyPresets) {
             this.partitioningPolicyPresets = partitioningPolicyPresets;
-        }
-
-        public List<ExecutionPolicyDescription> getExecutionPolicyPresets() {
-            return executionPolicyPresets;
         }
 
         public void setExecutionPolicyPresets(List<ExecutionPolicyDescription> executionPolicyPresets) {
             this.executionPolicyPresets = executionPolicyPresets;
         }
 
-        public List<ReplicationPolicyDescription> getReplicationPolicyPresets() {
-            return replicationPolicyPresets;
-        }
-
         public void setReplicationPolicyPresets(List<ReplicationPolicyDescription> replicationPolicyPresets) {
             this.replicationPolicyPresets = replicationPolicyPresets;
-        }
-
-        public List<CachingPolicyDescription> getCachingPolicyPresets() {
-            return cachingPolicyPresets;
         }
 
         public void setCachingPolicyPresets(List<CachingPolicyDescription> cachingPolicyPresets) {
@@ -125,6 +109,9 @@ public class TableOptionDescription {
         }
     }
 
+    /**
+     * Describe profile and associated settings to it
+     */
     public static class TableProfileDescription {
         private final String name;
         private final Map<String, String> labels;
@@ -221,6 +208,9 @@ public class TableOptionDescription {
             return allowedCachingPolicy;
         }
 
+        /**
+         * Builder to construct {@link TableProfileDescription}
+         */
         public static class Builder {
             String name;
             Map<String, String> labels;
@@ -302,9 +292,16 @@ public class TableOptionDescription {
         }
     }
 
+    /**
+     * Describe storage policy
+     * <p>
+     * For example
+     * which codec is used
+     * where sored log an etc
+     */
     public static class StoragePolicyDescription {
         private final String name;
-        private final Map<String,String> labels;
+        private final Map<String, String> labels;
 
         public StoragePolicyDescription(String name, Map<String, String> labels) {
             this.name = name;
@@ -320,9 +317,12 @@ public class TableOptionDescription {
         }
     }
 
+    /**
+     * Describe compaction policy
+     */
     public static class CompactionPolicyDescription {
         private final String name;
-        private final Map<String,String> labels;
+        private final Map<String, String> labels;
 
         public CompactionPolicyDescription(String name, Map<String, String> labels) {
             this.name = name;
@@ -338,9 +338,15 @@ public class TableOptionDescription {
         }
     }
 
+    /**
+     * Describe partition policy
+     * <p>
+     * For example
+     * split_threshold or is auto_split enabled
+     */
     public static class PartitioningPolicyDescription {
         private final String name;
-        private final Map<String,String> labels;
+        private final Map<String, String> labels;
 
         public PartitioningPolicyDescription(String name, Map<String, String> labels) {
             this.name = name;
@@ -356,9 +362,15 @@ public class TableOptionDescription {
         }
     }
 
+    /**
+     * Describe execution policy
+     * <p>
+     * For example
+     * pipeline_width or is bloom filter is used
+     */
     public static class ExecutionPolicyDescription {
         private final String name;
-        private final Map<String,String> labels;
+        private final Map<String, String> labels;
 
         public ExecutionPolicyDescription(String name, Map<String, String> labels) {
             this.name = name;
@@ -374,9 +386,14 @@ public class TableOptionDescription {
         }
     }
 
+    /**
+     * Describe replication policy
+     * <p>
+     * For example is followers enabled
+     */
     public static class ReplicationPolicyDescription {
         private final String name;
-        private final Map<String,String> labels;
+        private final Map<String, String> labels;
 
         public ReplicationPolicyDescription(String name, Map<String, String> labels) {
             this.name = name;
@@ -392,9 +409,12 @@ public class TableOptionDescription {
         }
     }
 
+    /**
+     * Describe caching policy
+     */
     public static class CachingPolicyDescription {
         private final String name;
-        private final Map<String,String> labels;
+        private final Map<String, String> labels;
 
         public CachingPolicyDescription(String name, Map<String, String> labels) {
             this.name = name;

--- a/table/src/main/java/tech/ydb/table/impl/BaseSession.java
+++ b/table/src/main/java/tech/ydb/table/impl/BaseSession.java
@@ -924,13 +924,14 @@ public abstract class BaseSession implements Session {
 
         TableOptionDescription.Builder builder = TableOptionDescription.newBuilder();
 
-        builder.setTableProfileDescriptions(new ArrayList<>());
+        List<TableOptionDescription.TableProfileDescription> tableProfileDescriptions = new ArrayList<>();
+        builder.setTableProfileDescriptions(tableProfileDescriptions);
         for (YdbTable.TableProfileDescription tableProfileDescription : describeResult.getTableProfilePresetsList()) {
             TableOptionDescription.TableProfileDescription.Builder descBuilder =
                     getDescBuilder(tableProfileDescription);
 
             TableOptionDescription.TableProfileDescription description = descBuilder.build();
-            builder.getTableProfileDescriptions().add(description);
+            tableProfileDescriptions.add(description);
         }
 
         List<TableOptionDescription.StoragePolicyDescription> storagePolicyDescription = new ArrayList<>();

--- a/table/src/main/java/tech/ydb/table/impl/BaseSession.java
+++ b/table/src/main/java/tech/ydb/table/impl/BaseSession.java
@@ -669,7 +669,8 @@ public abstract class BaseSession implements Session {
     }
 
     @Override
-    public CompletableFuture<Result<TableOptionDescription>> describeTableOptions(DescribeTableOptionsSettings settings) {
+    public CompletableFuture<Result<TableOptionDescription>> describeTableOptions(
+            DescribeTableOptionsSettings settings) {
         YdbTable.DescribeTableOptionsRequest request = YdbTable.DescribeTableOptionsRequest.newBuilder()
                 .setOperationParams(Operation.buildParams(settings.toOperationSettings()))
                 .build();
@@ -913,7 +914,8 @@ public abstract class BaseSession implements Session {
         return settings.build();
     }
 
-    private static Result<TableOptionDescription> mapDescribeTableOptions(Result<YdbTable.DescribeTableOptionsResult> describeTableOptionsResult) {
+    private static Result<TableOptionDescription> mapDescribeTableOptions(
+            Result<YdbTable.DescribeTableOptionsResult> describeTableOptionsResult) {
         if (!describeTableOptionsResult.isSuccess()) {
             return describeTableOptionsResult.map(null);
         }
@@ -924,65 +926,79 @@ public abstract class BaseSession implements Session {
 
         builder.setTableProfileDescriptions(new ArrayList<>());
         for (YdbTable.TableProfileDescription tableProfileDescription : describeResult.getTableProfilePresetsList()) {
-            TableOptionDescription.TableProfileDescription.Builder descBuilder = TableOptionDescription.TableProfileDescription.newBuilder();
-            descBuilder.setName(tableProfileDescription.getName());
-            descBuilder.setLabels(tableProfileDescription.getLabelsMap());
+            TableOptionDescription.TableProfileDescription.Builder descBuilder =
+                    getDescBuilder(tableProfileDescription);
 
-            descBuilder.setDefaultStoragePolicy(tableProfileDescription.getDefaultStoragePolicy());
-            descBuilder.setDefaultCompactionPolicy(tableProfileDescription.getDefaultCompactionPolicy());
-            descBuilder.setDefaultPartitioningPolicy(tableProfileDescription.getDefaultPartitioningPolicy());
-            descBuilder.setDefaultExecutionPolicy(tableProfileDescription.getDefaultExecutionPolicy());
-            descBuilder.setDefaultReplicationPolicy(tableProfileDescription.getDefaultReplicationPolicy());
-            descBuilder.setDefaultCachingPolicy(tableProfileDescription.getDefaultCachingPolicy());
-
-            descBuilder.setAllowedStoragePolicy(tableProfileDescription.getAllowedStoragePoliciesList());
-            descBuilder.setAllowedCompactionPolicy(tableProfileDescription.getAllowedCompactionPoliciesList());
-            descBuilder.setAllowedPartitioningPolicy(tableProfileDescription.getAllowedPartitioningPoliciesList());
-            descBuilder.setAllowedExecutionPolicy(tableProfileDescription.getAllowedExecutionPoliciesList());
-            descBuilder.setAllowedReplicationPolicy(tableProfileDescription.getAllowedReplicationPoliciesList());
-            descBuilder.setAllowedCachingPolicy(tableProfileDescription.getAllowedCachingPoliciesList());
-
-            TableOptionDescription.TableProfileDescription description = new TableOptionDescription.TableProfileDescription(descBuilder);
+            TableOptionDescription.TableProfileDescription description = descBuilder.build();
             builder.getTableProfileDescriptions().add(description);
         }
 
         List<TableOptionDescription.StoragePolicyDescription> storagePolicyDescription = new ArrayList<>();
         builder.setStoragePolicyPresets(storagePolicyDescription);
         for (YdbTable.StoragePolicyDescription iter : describeResult.getStoragePolicyPresetsList()) {
-            storagePolicyDescription.add(new TableOptionDescription.StoragePolicyDescription(iter.getName(), iter.getLabelsMap()));
+            storagePolicyDescription.add(
+                    new TableOptionDescription.StoragePolicyDescription(iter.getName(), iter.getLabelsMap()));
         }
 
         List<TableOptionDescription.CompactionPolicyDescription> compactionPolicyDescription = new ArrayList<>();
         builder.setCompactionPolicyPresets(compactionPolicyDescription);
         for (YdbTable.CompactionPolicyDescription iter : describeResult.getCompactionPolicyPresetsList()) {
-            compactionPolicyDescription.add(new TableOptionDescription.CompactionPolicyDescription(iter.getName(), iter.getLabelsMap()));
+            compactionPolicyDescription.add(
+                    new TableOptionDescription.CompactionPolicyDescription(iter.getName(), iter.getLabelsMap()));
         }
 
         List<TableOptionDescription.PartitioningPolicyDescription> partitioningPolicyPresets = new ArrayList<>();
         builder.setPartitioningPolicyPresets(partitioningPolicyPresets);
         for (YdbTable.PartitioningPolicyDescription iter : describeResult.getPartitioningPolicyPresetsList()) {
-            partitioningPolicyPresets.add(new TableOptionDescription.PartitioningPolicyDescription(iter.getName(), iter.getLabelsMap()));
+            partitioningPolicyPresets.add(
+                    new TableOptionDescription.PartitioningPolicyDescription(iter.getName(), iter.getLabelsMap()));
         }
 
         List<TableOptionDescription.ExecutionPolicyDescription> executionPolicyDescriptions = new ArrayList<>();
         builder.setExecutionPolicyPresets(executionPolicyDescriptions);
         for (YdbTable.ExecutionPolicyDescription iter : describeResult.getExecutionPolicyPresetsList()) {
-            executionPolicyDescriptions.add(new TableOptionDescription.ExecutionPolicyDescription(iter.getName(), iter.getLabelsMap()));
+            executionPolicyDescriptions.add(
+                    new TableOptionDescription.ExecutionPolicyDescription(iter.getName(), iter.getLabelsMap()));
         }
 
         List<TableOptionDescription.ReplicationPolicyDescription> replicationPolicyPresets = new ArrayList<>();
         builder.setReplicationPolicyPresets(replicationPolicyPresets);
         for (YdbTable.ReplicationPolicyDescription iter : describeResult.getReplicationPolicyPresetsList()) {
-            replicationPolicyPresets.add(new TableOptionDescription.ReplicationPolicyDescription(iter.getName(), iter.getLabelsMap()));
+            replicationPolicyPresets.add(
+                    new TableOptionDescription.ReplicationPolicyDescription(iter.getName(), iter.getLabelsMap()));
         }
 
         List<TableOptionDescription.CachingPolicyDescription> cachingPolicyPresets = new ArrayList<>();
         builder.setCachingPolicyPresets(cachingPolicyPresets);
         for (YdbTable.CachingPolicyDescription iter : describeResult.getCachingPolicyPresetsList()) {
-            cachingPolicyPresets.add(new TableOptionDescription.CachingPolicyDescription(iter.getName(), iter.getLabelsMap()));
+            cachingPolicyPresets.add(
+                    new TableOptionDescription.CachingPolicyDescription(iter.getName(), iter.getLabelsMap()));
         }
 
         return Result.success(new TableOptionDescription(builder));
+    }
+
+    private static TableOptionDescription.TableProfileDescription.Builder getDescBuilder(
+            YdbTable.TableProfileDescription tableProfileDescription) {
+        TableOptionDescription.TableProfileDescription.Builder descBuilder =
+                TableOptionDescription.TableProfileDescription.newBuilder();
+        descBuilder.setName(tableProfileDescription.getName());
+        descBuilder.setLabels(tableProfileDescription.getLabelsMap());
+
+        descBuilder.setDefaultStoragePolicy(tableProfileDescription.getDefaultStoragePolicy());
+        descBuilder.setDefaultCompactionPolicy(tableProfileDescription.getDefaultCompactionPolicy());
+        descBuilder.setDefaultPartitioningPolicy(tableProfileDescription.getDefaultPartitioningPolicy());
+        descBuilder.setDefaultExecutionPolicy(tableProfileDescription.getDefaultExecutionPolicy());
+        descBuilder.setDefaultReplicationPolicy(tableProfileDescription.getDefaultReplicationPolicy());
+        descBuilder.setDefaultCachingPolicy(tableProfileDescription.getDefaultCachingPolicy());
+
+        descBuilder.setAllowedStoragePolicy(tableProfileDescription.getAllowedStoragePoliciesList());
+        descBuilder.setAllowedCompactionPolicy(tableProfileDescription.getAllowedCompactionPoliciesList());
+        descBuilder.setAllowedPartitioningPolicy(tableProfileDescription.getAllowedPartitioningPoliciesList());
+        descBuilder.setAllowedExecutionPolicy(tableProfileDescription.getAllowedExecutionPoliciesList());
+        descBuilder.setAllowedReplicationPolicy(tableProfileDescription.getAllowedReplicationPoliciesList());
+        descBuilder.setAllowedCachingPolicy(tableProfileDescription.getAllowedCachingPoliciesList());
+        return descBuilder;
     }
 
 

--- a/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
+++ b/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
@@ -248,7 +248,8 @@ public interface TableRpc extends AutoCloseable {
      * @param settings rpc call settings
      * @return GrpcReadStream object that allows to start and cancel the stream
      */
-    CompletableFuture<Result<YdbTable.DescribeTableOptionsResult>> describeTableOptions(YdbTable.DescribeTableOptionsRequest request,
-                                                                         GrpcRequestSettings settings);
+    CompletableFuture<Result<YdbTable.DescribeTableOptionsResult>> describeTableOptions(
+            YdbTable.DescribeTableOptionsRequest request,
+            GrpcRequestSettings settings);
 }
 

--- a/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
+++ b/table/src/main/java/tech/ydb/table/rpc/TableRpc.java
@@ -7,6 +7,7 @@ import tech.ydb.core.Result;
 import tech.ydb.core.Status;
 import tech.ydb.core.grpc.GrpcReadStream;
 import tech.ydb.core.grpc.GrpcRequestSettings;
+import tech.ydb.proto.table.YdbTable;
 import tech.ydb.proto.table.YdbTable.AlterTableRequest;
 import tech.ydb.proto.table.YdbTable.BeginTransactionRequest;
 import tech.ydb.proto.table.YdbTable.BeginTransactionResult;
@@ -240,5 +241,14 @@ public interface TableRpc extends AutoCloseable {
      * @return completable future with status of operation
      */
     CompletableFuture<Status> bulkUpsert(BulkUpsertRequest request, GrpcRequestSettings settings);
+
+    /**
+     * Describe table request.
+     * @param request request proto
+     * @param settings rpc call settings
+     * @return GrpcReadStream object that allows to start and cancel the stream
+     */
+    CompletableFuture<Result<YdbTable.DescribeTableOptionsResult>> describeTableOptions(YdbTable.DescribeTableOptionsRequest request,
+                                                                         GrpcRequestSettings settings);
 }
 

--- a/table/src/main/java/tech/ydb/table/rpc/grpc/GrpcTableRpc.java
+++ b/table/src/main/java/tech/ydb/table/rpc/grpc/GrpcTableRpc.java
@@ -227,6 +227,16 @@ public final class GrpcTableRpc implements TableRpc {
     }
 
     @Override
+    public CompletableFuture<Result<YdbTable.DescribeTableOptionsResult>> describeTableOptions(
+            YdbTable.DescribeTableOptionsRequest request, GrpcRequestSettings settings
+    ) {
+        return transport.unaryCall(TableServiceGrpc.getDescribeTableOptionsMethod(), settings, request)
+                .thenApply(OperationBinder.bindSync(
+                        YdbTable.DescribeTableOptionsResponse::getOperation, YdbTable.DescribeTableOptionsResult.class
+                ));
+    }
+
+    @Override
     public String getDatabase() {
         return transport.getDatabase();
     }

--- a/table/src/main/java/tech/ydb/table/settings/DescribeTableOptionsSettings.java
+++ b/table/src/main/java/tech/ydb/table/settings/DescribeTableOptionsSettings.java
@@ -1,0 +1,8 @@
+package tech.ydb.table.settings;
+
+/**
+ *
+ */
+public class DescribeTableOptionsSettings extends RequestSettings<DescribeTableSettings> {
+
+}

--- a/table/src/main/java/tech/ydb/table/settings/DescribeTableOptionsSettings.java
+++ b/table/src/main/java/tech/ydb/table/settings/DescribeTableOptionsSettings.java
@@ -1,8 +1,10 @@
 package tech.ydb.table.settings;
 
 /**
+ * Setting for describe able options.
  *
+ * @author Evgeny Kuvardin
  */
-public class DescribeTableOptionsSettings extends RequestSettings<DescribeTableSettings> {
+public class DescribeTableOptionsSettings extends RequestSettings<DescribeTableOptionsSettings> {
 
 }

--- a/table/src/test/java/tech/ydb/table/SessionStub.java
+++ b/table/src/test/java/tech/ydb/table/SessionStub.java
@@ -9,6 +9,7 @@ import tech.ydb.core.Status;
 import tech.ydb.core.grpc.GrpcReadStream;
 import tech.ydb.core.utils.FutureTools;
 import tech.ydb.table.description.TableDescription;
+import tech.ydb.table.description.TableOptionDescription;
 import tech.ydb.table.query.DataQuery;
 import tech.ydb.table.query.DataQueryResult;
 import tech.ydb.table.query.ExplainDataQueryResult;
@@ -23,6 +24,7 @@ import tech.ydb.table.settings.CommitTxSettings;
 import tech.ydb.table.settings.CopyTableSettings;
 import tech.ydb.table.settings.CopyTablesSettings;
 import tech.ydb.table.settings.CreateTableSettings;
+import tech.ydb.table.settings.DescribeTableOptionsSettings;
 import tech.ydb.table.settings.DescribeTableSettings;
 import tech.ydb.table.settings.DropTableSettings;
 import tech.ydb.table.settings.ExecuteDataQuerySettings;
@@ -125,6 +127,11 @@ public class SessionStub implements Session {
         String query, ExplainDataQuerySettings settings)
     {
         return notImplemented("explainDataQuery()");
+    }
+
+    @Override
+    public CompletableFuture<Result<TableOptionDescription>> describeTableOptions(DescribeTableOptionsSettings settings) {
+        return notImplemented("describeTableOptions()");
     }
 
     @Override

--- a/table/src/test/java/tech/ydb/table/TableRpcStub.java
+++ b/table/src/test/java/tech/ydb/table/TableRpcStub.java
@@ -180,6 +180,11 @@ public class TableRpcStub implements TableRpc {
     }
 
     @Override
+    public CompletableFuture<Result<YdbTable.DescribeTableOptionsResult>> describeTableOptions(YdbTable.DescribeTableOptionsRequest request, GrpcRequestSettings settings) {
+        return notImplemented("describeTableOptions()");
+    }
+
+    @Override
     public String getDatabase() {
         return "";
     }

--- a/table/src/test/java/tech/ydb/table/integration/TableOptionTest.java
+++ b/table/src/test/java/tech/ydb/table/integration/TableOptionTest.java
@@ -1,0 +1,232 @@
+package tech.ydb.table.integration;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+
+import org.junit.Test;
+
+import tech.ydb.core.Result;
+import tech.ydb.core.StatusCode;
+import tech.ydb.table.Session;
+import tech.ydb.table.SessionRetryContext;
+import tech.ydb.table.description.TableOptionDescription;
+import tech.ydb.table.impl.SimpleTableClient;
+import tech.ydb.table.rpc.grpc.GrpcTableRpc;
+import tech.ydb.table.settings.DescribeTableOptionsSettings;
+import tech.ydb.test.junit4.GrpcTransportRule;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test connected to get described table options.
+ *
+ * @author Evgeny Kuvardin
+ */
+public class TableOptionTest {
+
+    @ClassRule
+    public final static GrpcTransportRule ydbTransport = new GrpcTransportRule();
+
+    private final SimpleTableClient tableClient = SimpleTableClient.newClient(
+            GrpcTableRpc.useTransport(ydbTransport)
+    ).build();
+
+    private final SessionRetryContext ctx = SessionRetryContext.create(tableClient).build();
+
+    /**
+     * Test checks that call to describe table options works with the default settings
+     */
+    @Test
+    public void tableOptionsTestShouldGetGlobalOptionsWithDefaultSettings() {
+        Result<TableOptionDescription> describeResult = ctx.supplyResult(Session::describeTableOptions).join();
+
+        Assert.assertTrue("Describe table options" + describeResult.getStatus(), describeResult.isSuccess());
+
+        TableOptionDescription tableOptionDescription = describeResult.getValue();
+
+        checkTableOptions(tableOptionDescription);
+    }
+
+    /**
+     * Test checks that call to describe table options works with all set options
+     */
+    @Test
+    public void tableOptionsTestShouldGetGlobalOptions() {
+        Result<TableOptionDescription> describeResult = ctx.supplyResult(session -> {
+            DescribeTableOptionsSettings settings = new DescribeTableOptionsSettings();
+            settings.setTraceId("traceId");
+            settings.setReportCostInfo(true);
+            settings.setTimeout(10, TimeUnit.SECONDS);
+            settings.setCancelAfter(Duration.ofSeconds(8));
+            settings.setOperationTimeout(Duration.ofSeconds(8));
+            return session.describeTableOptions(settings);
+        }).join();
+        Assert.assertTrue("Describe table options" + describeResult.getStatus(), describeResult.isSuccess());
+
+        TableOptionDescription tableOptionDescription = describeResult.getValue();
+        checkTableOptions(tableOptionDescription);
+    }
+
+    /**
+     * Test checks that call to describe table options fails when we set client timeout as low as possible
+     * and request can't be completed in this time.
+     * We should catch StatusCode == CLIENT_DEADLINE_EXPIRED
+     */
+    @Test
+    public void tableOptionsTestShouldFailedInOrderToTimeout() {
+        Result<TableOptionDescription> describeResult = ctx.supplyResult(session -> {
+            DescribeTableOptionsSettings settings = new DescribeTableOptionsSettings();
+            settings.setTraceId("traceId");
+            settings.setReportCostInfo(true);
+            settings.setTimeout(1, TimeUnit.NANOSECONDS);
+            return session.describeTableOptions(settings);
+        }).join();
+        Assert.assertFalse("Describe table options" + describeResult.getStatus(), describeResult.isSuccess());
+        Assert.assertEquals(StatusCode.CLIENT_DEADLINE_EXPIRED, describeResult.getStatus().getCode());
+    }
+
+    private void checkTableOptions(TableOptionDescription tableOptionDescription) {
+        checkStoragePresets(tableOptionDescription);
+
+        checkPolicyPresets(tableOptionDescription);
+
+        checkCompactionPolicyPresets(tableOptionDescription);
+
+        checkExecutionPolicyPresets(tableOptionDescription);
+
+        checkPartitioningPolicyPresets(tableOptionDescription);
+
+        checkReplicationPolicyPresets(tableOptionDescription);
+
+        checkTableProfileDescriptions(tableOptionDescription);
+    }
+
+
+    private void checkStoragePresets(TableOptionDescription tableOptionDescription) {
+        Assert.assertNotNull(tableOptionDescription.getStoragePolicyPresets());
+        List<TableOptionDescription.StoragePolicyDescription> storagePolicyDescription = tableOptionDescription.getStoragePolicyPresets();
+        Assert.assertEquals(2, storagePolicyDescription.size());
+
+
+        for (TableOptionDescription.StoragePolicyDescription v1 : storagePolicyDescription) {
+            if (v1.getName().equals("default")) {
+                checkDefaultStoragePolicy(v1);
+            } else {
+                checkLogLz4StoragePolicy(v1);
+            }
+        }
+    }
+
+    private void checkTableProfileDescriptions(TableOptionDescription tableOptionDescription) {
+        Assert.assertNotNull(tableOptionDescription.getTableProfileDescriptions());
+        List<TableOptionDescription.TableProfileDescription> tableProfileDescriptions = tableOptionDescription.getTableProfileDescriptions();
+
+        Assert.assertFalse(tableProfileDescriptions.isEmpty());
+
+        Optional<TableOptionDescription.TableProfileDescription> t = tableProfileDescriptions.stream().filter(p -> p.getName().equals("default")).findFirst();
+        Assert.assertTrue(t.isPresent());
+        TableOptionDescription.TableProfileDescription v = t.get();
+        Assert.assertEquals("default", v.getName());
+        Assert.assertNotNull(v.getLabels());
+        Assert.assertEquals("default", v.getDefaultCachingPolicy());
+        Assert.assertEquals("default", v.getDefaultCompactionPolicy());
+        Assert.assertEquals("default", v.getDefaultExecutionPolicy());
+        Assert.assertEquals("default", v.getDefaultPartitioningPolicy());
+        Assert.assertEquals("default", v.getDefaultReplicationPolicy());
+        Assert.assertEquals("default", v.getDefaultStoragePolicy());
+
+        Assert.assertNotNull(v.getAllowedCachingPolicy());
+        Assert.assertTrue(v.getAllowedCachingPolicy().stream().anyMatch(p -> p.equals("default")));
+
+        Assert.assertNotNull(v.getAllowedCompactionPolicy());
+        Assert.assertTrue(v.getAllowedCompactionPolicy().stream().anyMatch(p -> p.equals("default")));
+
+        Assert.assertNotNull(v.getAllowedExecutionPolicy());
+        Assert.assertTrue(v.getAllowedExecutionPolicy().stream().anyMatch(p -> p.equals("default")));
+
+        Assert.assertNotNull(v.getAllowedPartitioningPolicy());
+        Assert.assertTrue(v.getAllowedPartitioningPolicy().stream().anyMatch(p -> p.equals("default")));
+
+        Assert.assertNotNull(v.getAllowedReplicationPolicy());
+        Assert.assertTrue(v.getAllowedReplicationPolicy().stream().anyMatch(p -> p.equals("default")));
+
+        Assert.assertNotNull(v.getAllowedStoragePolicy());
+        Assert.assertTrue(v.getAllowedStoragePolicy().stream().anyMatch(p -> p.equals("default")));
+    }
+
+    private void checkReplicationPolicyPresets(TableOptionDescription tableOptionDescription) {
+        Assert.assertNotNull(tableOptionDescription.getReplicationPolicyPresets());
+        List<TableOptionDescription.ReplicationPolicyDescription> replicationPolicyPresets = tableOptionDescription.getReplicationPolicyPresets();
+
+        Assert.assertEquals(1, replicationPolicyPresets.size());
+        Assert.assertEquals("default", replicationPolicyPresets.get(0).getName());
+        Assert.assertNotNull(replicationPolicyPresets.get(0).getLabels());
+        Assert.assertFalse(replicationPolicyPresets.get(0).getLabels().isEmpty());
+    }
+
+    private void checkPartitioningPolicyPresets(TableOptionDescription tableOptionDescription) {
+        Assert.assertNotNull(tableOptionDescription.getPartitioningPolicyPresets());
+        List<TableOptionDescription.PartitioningPolicyDescription> partitioningPolicyPresets = tableOptionDescription.getPartitioningPolicyPresets();
+
+        Assert.assertEquals(1, partitioningPolicyPresets.size());
+        Assert.assertEquals("default", partitioningPolicyPresets.get(0).getName());
+        Assert.assertNotNull(partitioningPolicyPresets.get(0).getLabels());
+        Assert.assertFalse(partitioningPolicyPresets.get(0).getLabels().isEmpty());
+    }
+
+    private void checkExecutionPolicyPresets(TableOptionDescription tableOptionDescription) {
+
+        Assert.assertNotNull(tableOptionDescription.getExecutionPolicyPresets());
+        List<TableOptionDescription.ExecutionPolicyDescription> executionPolicyPresets = tableOptionDescription.getExecutionPolicyPresets();
+
+        Assert.assertEquals(1, executionPolicyPresets.size());
+        Assert.assertEquals("default", executionPolicyPresets.get(0).getName());
+        Assert.assertNotNull(executionPolicyPresets.get(0).getLabels());
+        Assert.assertFalse(executionPolicyPresets.get(0).getLabels().isEmpty());
+    }
+
+    private void checkCompactionPolicyPresets(TableOptionDescription tableOptionDescription) {
+        Assert.assertNotNull(tableOptionDescription.getCompactionPolicyPresets());
+        List<TableOptionDescription.CompactionPolicyDescription> compactionPolicyPresets = tableOptionDescription.getCompactionPolicyPresets();
+
+        Assert.assertEquals(1, compactionPolicyPresets.size());
+        Assert.assertEquals("default", compactionPolicyPresets.get(0).getName());
+        Assert.assertNotNull(compactionPolicyPresets.get(0).getLabels());
+        Assert.assertTrue(compactionPolicyPresets.get(0).getLabels().isEmpty());
+    }
+
+    private void checkPolicyPresets(TableOptionDescription tableOptionDescription) {
+        Assert.assertNotNull(tableOptionDescription.getCachingPolicyPresets());
+        List<TableOptionDescription.CachingPolicyDescription> cachingPolicyPresets = tableOptionDescription.getCachingPolicyPresets();
+
+        Assert.assertEquals(1, cachingPolicyPresets.size());
+        Assert.assertEquals("default", cachingPolicyPresets.get(0).getName());
+        Assert.assertNotNull(cachingPolicyPresets.get(0).getLabels());
+        Assert.assertTrue(cachingPolicyPresets.get(0).getLabels().isEmpty());
+    }
+
+    private void checkLogLz4StoragePolicy(TableOptionDescription.StoragePolicyDescription storagePolicyDescription) {
+        Map<String, String> map2 = storagePolicyDescription.getLabels();
+        Assert.assertEquals("log_lz4", storagePolicyDescription.getName());
+        Assert.assertEquals("hdd", map2.get("data"));
+        Assert.assertEquals("false", map2.get("in_memory"));
+        Assert.assertEquals("hdd", map2.get("log"));
+        Assert.assertEquals("hdd", map2.get("syslog"));
+        Assert.assertEquals("lz4", map2.get("codec"));
+    }
+
+    private void checkDefaultStoragePolicy(TableOptionDescription.StoragePolicyDescription storagePolicyDescription) {
+        Assert.assertEquals("default", storagePolicyDescription.getName());
+        Map<String, String> map = storagePolicyDescription.getLabels();
+        Assert.assertEquals("hdd", map.get("data"));
+        Assert.assertEquals("false", map.get("in_memory"));
+        Assert.assertEquals("hdd", map.get("log"));
+        Assert.assertEquals("hdd", map.get("syslog"));
+        Assert.assertEquals("none", map.get("codec"));
+    }
+
+}

--- a/table/src/test/java/tech/ydb/table/integration/TableOptionTest.java
+++ b/table/src/test/java/tech/ydb/table/integration/TableOptionTest.java
@@ -38,7 +38,7 @@ public class TableOptionTest {
     private final SessionRetryContext ctx = SessionRetryContext.create(tableClient).build();
 
     /**
-     * Test checks that call to describe table options works with the default settings
+     * The test checks that the call to describe table options works with the default settings.
      */
     @Test
     public void tableOptionsTestShouldGetGlobalOptionsWithDefaultSettings() {
@@ -52,7 +52,7 @@ public class TableOptionTest {
     }
 
     /**
-     * Test checks that call to describe table options works with all set options
+     * The test checks that the call to describe table options works with all set options
      */
     @Test
     public void tableOptionsTestShouldGetGlobalOptions() {
@@ -72,8 +72,8 @@ public class TableOptionTest {
     }
 
     /**
-     * Test checks that call to describe table options fails when we set client timeout as low as possible
-     * and request can't be completed in this time.
+     * The test checks that the call to describe table options fails when we set the client timeout as low as possible.
+     * and the request can't be completed in this time.
      * We should catch StatusCode == CLIENT_DEADLINE_EXPIRED
      */
     @Test


### PR DESCRIPTION
Connected to https://github.com/ydb-platform/ydb-java-sdk/issues/405

Add DescribeTableOptions.
Add tests. So it's difficult to add in a YDB custom TableProfileDescription while running tests. So that test covers default profiles, caching options and profile description, which is set up in the default container.
So try to check only default values and don't dive deep.

For example:

1. In PartitioningPolicyDescription, don't check if labels contain split_threshold or auto_split. 
2. In ExecutionPolicyDescription, don't check if labels contain pipeline_width or bloom filter.

Because these values can be changed in future releases, tests shouldn't fail if some values change.

Only check StoragePolicyDescription in deep because I think its values are more static. 