### PR TITLE
Add max_active_partitions support to topic operations

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/impl/TopicClientImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/impl/TopicClientImpl.java
@@ -160,6 +160,10 @@ public class TopicClientImpl implements TopicClient {
             if (minActivePartitions != null) {
                 builder.setSetMinActivePartitions(minActivePartitions);
             }
+            Long maxActivePartitions = partitioningSettings.getMaxActivePartitions();
+            if (maxActivePartitions != null) {
+                builder.setSetMaxActivePartitions(maxActivePartitions);
+            }
             Long partitionCountLimit = partitioningSettings.getPartitionCountLimit();
             if (partitionCountLimit != null) {
                 builder.setSetPartitionCountLimit(partitionCountLimit);
@@ -321,6 +325,7 @@ public class TopicClientImpl implements TopicClient {
 
         PartitioningSettings.Builder partitioningDescription = PartitioningSettings.newBuilder()
                 .setMinActivePartitions(partitioningSettings.getMinActivePartitions())
+                .setMaxActivePartitions(partitioningSettings.getMaxActivePartitions())
                 .setPartitionCountLimit(partitioningSettings.getPartitionCountLimit())
                 .setAutoPartitioningStrategy(fromProto(autoPartitioningStrategy));
 

--- a/topic/src/main/java/tech/ydb/topic/settings/AlterPartitioningSettings.java
+++ b/topic/src/main/java/tech/ydb/topic/settings/AlterPartitioningSettings.java
@@ -9,6 +9,8 @@ public class AlterPartitioningSettings {
     @Nullable
     private final Long minActivePartitions;
     @Nullable
+    private final Long maxActivePartitions;
+    @Nullable
     private final Long partitionCountLimit;
     @Nullable
     private final AutoPartitioningStrategy autoPartitioningStrategy;
@@ -17,6 +19,7 @@ public class AlterPartitioningSettings {
 
     private AlterPartitioningSettings(Builder builder) {
         this.minActivePartitions = builder.minActivePartitions;
+        this.maxActivePartitions = builder.maxActivePartitions;
         this.partitionCountLimit = builder.partitionCountLimit;
         this.autoPartitioningStrategy = builder.autoPartitioningStrategy;
         this.writeStrategySettings = builder.writeStrategySettings;
@@ -29,6 +32,11 @@ public class AlterPartitioningSettings {
     @Nullable
     public Long getMinActivePartitions() {
         return minActivePartitions;
+    }
+
+    @Nullable
+    public Long getMaxActivePartitions() {
+        return maxActivePartitions;
     }
 
     @Nullable
@@ -51,6 +59,7 @@ public class AlterPartitioningSettings {
      */
     public static class Builder {
         private Long minActivePartitions = null;
+        private Long maxActivePartitions = null;
         private Long partitionCountLimit = null;
         private AutoPartitioningStrategy autoPartitioningStrategy = null;
         private AlterAutoPartitioningWriteStrategySettings writeStrategySettings = null;
@@ -66,10 +75,21 @@ public class AlterPartitioningSettings {
         }
 
         /**
+         * @param maxActivePartitions  maximum partition count auto merge would stop working at.
+         *                             Zero value means default - 1.
+         * @return settings builder
+         */
+        public Builder setMaxActivePartitions(long maxActivePartitions) {
+            this.maxActivePartitions = maxActivePartitions;
+            return this;
+        }
+
+        /**
          * @param partitionCountLimit  Limit for total partition count, including active (open for write) and
          *                             read-only partitions.
          *                             Zero value means default - 100.
          * @return settings builder
+         * @deprecated Use {@link #setMaxActivePartitions(long)} instead
          */
         public Builder setPartitionCountLimit(long partitionCountLimit) {
             this.partitionCountLimit = partitionCountLimit;

--- a/topic/src/main/java/tech/ydb/topic/settings/PartitioningSettings.java
+++ b/topic/src/main/java/tech/ydb/topic/settings/PartitioningSettings.java
@@ -7,12 +7,14 @@ import java.util.Objects;
  */
 public class PartitioningSettings {
     private final long minActivePartitions;
+    private final long maxActivePartitions;
     private final long partitionCountLimit;
     private final AutoPartitioningStrategy autoPartitioningStrategy;
     private final AutoPartitioningWriteStrategySettings writeStrategySettings;
 
     private PartitioningSettings(Builder builder) {
         this.minActivePartitions = builder.minActivePartitions;
+        this.maxActivePartitions = builder.maxActivePartitions;
         this.partitionCountLimit = builder.partitionCountLimit;
         this.autoPartitioningStrategy = builder.autoPartitioningStrategy;
         this.writeStrategySettings = builder.writeStrategySettings;
@@ -27,9 +29,18 @@ public class PartitioningSettings {
     }
 
     /**
+     * @return  maximum partition count auto merge would stop working at.
+     *                             Zero value means default - 1.
+     */
+    public long getMaxActivePartitions() {
+        return maxActivePartitions;
+    }
+
+    /**
      * @return  Limit for total partition count, including active (open for write) and
      *                             read-only partitions.
      *                             Zero value means default - 100.
+     * @deprecated Use {@link #getMaxActivePartitions()} instead
      */
     public long getPartitionCountLimit() {
         return partitionCountLimit;
@@ -58,6 +69,7 @@ public class PartitioningSettings {
      */
     public static class Builder {
         private long minActivePartitions = 0;
+        private long maxActivePartitions = 0;
         private long partitionCountLimit = 0;
         private AutoPartitioningStrategy autoPartitioningStrategy = AutoPartitioningStrategy.DISABLED;
         private AutoPartitioningWriteStrategySettings writeStrategySettings = null;
@@ -73,11 +85,23 @@ public class PartitioningSettings {
         }
 
         /**
+         * @param maxActivePartitions  maximum partition count auto merge would stop working at.
+         *                             Zero value means default - 1.
+         * @return settings builder
+         */
+        public Builder setMaxActivePartitions(long maxActivePartitions) {
+            this.maxActivePartitions = maxActivePartitions;
+            return this;
+        }
+
+        /**
          * @param partitionCountLimit  Limit for total partition count, including active (open for write) and
          *                             read-only partitions.
          *                             Zero value means default - 100.
          * @return settings builder
+         * @deprecated Use {@link #setMaxActivePartitions(long)} instead.
          */
+        @Deprecated
         public Builder setPartitionCountLimit(long partitionCountLimit) {
             this.partitionCountLimit = partitionCountLimit;
             return this;
@@ -120,6 +144,7 @@ public class PartitioningSettings {
         }
         PartitioningSettings that = (PartitioningSettings) o;
         return minActivePartitions == that.minActivePartitions &&
+                maxActivePartitions == that.maxActivePartitions &&
                 partitionCountLimit == that.partitionCountLimit &&
                 autoPartitioningStrategy == that.autoPartitioningStrategy &&
                 Objects.equals(writeStrategySettings, that.writeStrategySettings);
@@ -127,6 +152,12 @@ public class PartitioningSettings {
 
     @Override
     public int hashCode() {
-        return Objects.hash(minActivePartitions, partitionCountLimit, autoPartitioningStrategy, writeStrategySettings);
+        return Objects.hash(
+                minActivePartitions,
+                maxActivePartitions,
+                partitionCountLimit,
+                autoPartitioningStrategy,
+                writeStrategySettings
+        );
     }
 }

--- a/topic/src/test/java/tech/ydb/topic/impl/YdbTopicsIntegrationTest.java
+++ b/topic/src/test/java/tech/ydb/topic/impl/YdbTopicsIntegrationTest.java
@@ -268,7 +268,7 @@ public class YdbTopicsIntegrationTest {
                         .setDownUtilizationPercent(20)
                         .build())
                 .setMinActivePartitions(1)
-                .setPartitionCountLimit(0)
+                .setMaxActivePartitions(1)
                 .build();
 
         Assert.assertEquals(expectedPartitioningSettings, actualPartitioningSettings);


### PR DESCRIPTION
### Summary

This PR introduces support for the max_active_partitions parameter in topic control plane operations, providing more precise control over partition auto-merging behavior.

### Changes

Added new maxActivePartitions field and corresponding getters/setters in partitioning settings classes
Implemented support for setting and retrieving maxActivePartitions in topic client implementation
Deprecated partitionCountLimit in favor of maxActivePartitions as described in the YDB proto specifications - https://github.com/ydb-platform/ydb/blob/7b288ef1f52ea97c71014dac8ee95bbde82bd6e3/ydb/public/api/protos/ydb_topic.proto#L909
