### PR TITLE
Attaching stream ID to SessionBase logs

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/read/impl/ReadSession.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/ReadSession.java
@@ -15,11 +15,8 @@ import tech.ydb.topic.impl.SessionBase;
 public abstract class ReadSession extends SessionBase<FromServer, FromClient> {
     private static final Logger logger = LoggerFactory.getLogger(ReadSession.class);
 
-    protected final String streamId;
-
     public ReadSession(TopicRpc rpc, String streamId) {
-        super(rpc.readSession(streamId));
-        this.streamId = streamId;
+        super(rpc.readSession(streamId), streamId);
     }
 
     @Override

--- a/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
@@ -171,12 +171,12 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
             if (error != null) {
                 currentSession.closeDueToError(null,
                         new RuntimeException("Restarting read session due to transaction " + transaction.getId() +
-                                " with partition offsets from read session " + currentSession.streamId +
+                                " with partition offsets from read session " + currentSession.getStreamId() +
                                 " was not committed with reason: " + error));
             } else if (!status.isSuccess()) {
                 currentSession.closeDueToError(null,
                         new RuntimeException("Restarting read session due to transaction " + transaction.getId() +
-                                " with partition offsets from read session " + currentSession.streamId +
+                                " with partition offsets from read session " + currentSession.getStreamId() +
                                 " was not committed with status: " + status));
             }
         });

--- a/topic/src/main/java/tech/ydb/topic/write/impl/WriteSession.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/WriteSession.java
@@ -14,11 +14,8 @@ import tech.ydb.topic.impl.SessionBase;
 public abstract class WriteSession extends SessionBase<FromServer, FromClient> {
     private static final Logger logger = LoggerFactory.getLogger(WriteSession.class);
 
-    protected final String streamId;
-
     public WriteSession(TopicRpc rpc, String streamId) {
-        super(rpc.writeSession(streamId));
-        this.streamId = streamId;
+        super(rpc.writeSession(streamId), streamId);
     }
 
     @Override


### PR DESCRIPTION
Without a stream ID, it's hard to tell to which session messages like `Session start` and `Session stop` belong.