### PR TITLE
Java api compatibility check report

### DIFF
--- a/.github/workflows/breaking.yaml
+++ b/.github/workflows/breaking.yaml
@@ -1,0 +1,53 @@
+name: breaking
+on:
+  pull_request:
+
+jobs:
+  broken-changes:
+    concurrency:
+      group: broken-changes-${{ github.ref }}
+      cancel-in-progress: true
+    if: (!contains(github.event.pull_request.labels.*.name, 'broken changes'))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build
+        run: mvn -DskipTests -ntp install
+
+      - name: Check broken API changes
+        run: set -o pipefail && mvn org.revapi:revapi-maven-plugin:report-aggregate -DskipTests -ntp
+
+      - name: Generate backward compatibility report
+        run: |
+          cat changes.txt
+          touch report.txt
+
+          if [ -s changes.txt ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "Backward compatibility check report" >> report.txt
+            echo "======" >> report.txt
+            cat changes.txt >> report.txt
+          else
+            echo "CHANGES_DETECTED=false" >> $GITHUB_ENV
+          fi
+
+      # Skip comment for forks - GITHUB_TOKEN doesn't have write permissions for external PRs
+      - name: Comment Report
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository && env.CHANGES_DETECTED == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: report.txt
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          header: diff

--- a/config/revapi-report-template.ftl
+++ b/config/revapi-report-template.ftl
@@ -1,0 +1,16 @@
+<#if reports?has_content>
+```
+<#list analysis.oldApi.archives as archive>${archive.name}<#sep>, </#list>
+<#list analysis.newApi.archives as archive>${archive.name}<#sep>, </#list>
+```
+
+<#list reports as report>
+>***Old: ${report.oldElement!"<none>"}***
+>***New: ${report.newElement!"<none>"}***
+    <#list report.differences as diff>
+> ${diff.code}<#if diff.description??>: ${diff.description}</#if>
+    </#list>
+
+</#list>
+---
+</#if>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <!-- last version with JDK8 compability -->
         <apache.arrow.version>17.0.0</apache.arrow.version>
         <opentelemetry.version>1.59.0</opentelemetry.version>
+        <maven-revapi-plugin.version>0.15.1</maven-revapi-plugin.version>
     </properties>
 
     <licenses>
@@ -185,6 +186,42 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <version>${maven-revapi-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.revapi</groupId>
+                        <artifactId>revapi-java</artifactId>
+                        <version>0.28.4</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.revapi</groupId>
+                        <artifactId>revapi-reporter-text</artifactId>
+                        <version>${maven-revapi-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <analysisConfiguration>
+                        <revapi.filter>
+                            <archives>
+                                <include>
+                                    <item>tech.ydb.*</item>
+                                </include>
+                            </archives>
+                        </revapi.filter>
+                        <revapi.reporter.text>
+                            <minSeverity>BREAKING</minSeverity>
+                            <minCriticality>documented</minCriticality>
+                            <output>changes.txt</output>
+                            <template>/config/revapi-report-template.ftl</template>
+                            <append>true</append>
+                            <keepEmptyFile>true</keepEmptyFile>
+                        </revapi.reporter.text>
+                    </analysisConfiguration>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Backward compatibility report 

Added revapi maven plugin https://revapi.org/revapi-site/main/index.html , ftl template and corresponding github action to provide backward compatibility report

Short description: revapi compares two compiled versions of module/library only. So the 'install' goal is required to make it work. You can provide versions to compare as arguments:

```bash
-Drevapi.oldVersion=O.O.O -Drevapi.newVersion=X.X.X
```

Revapi supports web and txt reports. Last one is used here with freemarker template. 

```
<revapi.filter>
    <archives>
        <include>
            <item>tech.ydb.*</item>
        </include>
    </archives>
</revapi.filter>
```

Block above is required for packages scan process management

Comment looks this way:
<img width="1054" height="729" alt="image" src="https://github.com/user-attachments/assets/e58f553d-6aa3-48a7-bab0-b84a8053db34" />
