### PR TITLE
Add native-sdk Codecov component

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+# Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
+# so native-SDK coverage is queryable identically via the Codecov API
+# (?component_id=native-sdk), regardless of how each repo tags its uploads.
+component_management:
+  individual_components:
+    - component_id: native-sdk
+      name: Native SDK


### PR DESCRIPTION
Adds `.github/codecov.yml` defining a path-based `native-sdk` component that aggregates the production modules (core, table, topic, query, scheme, coordination, common, auth-api, auth-providers, export).

The `tests/*` test-support modules are intentionally excluded so they don't dilute the SDK number.

The `native-sdk` `component_id` is shared across all YDB SDK repos so native-SDK coverage is queryable uniformly via the Codecov API (`?component_id=native-sdk`). Purely additive — no status checks or comment changes.