### PR TITLE
SLO: fix label-driven triggering and split report into a base-context workflow

### DIFF
--- a/.github/workflows/slo-report.yml
+++ b/.github/workflows/slo-report.yml
@@ -1,0 +1,57 @@
+name: slo-report
+
+# Runs in the base-repo context (not the fork's), so it has the
+# pull-requests: write permission needed to publish reports and edit
+# labels — which fork-triggered SLO runs do not.
+
+on:
+  workflow_run:
+    workflows: ["SLO"]
+    types:
+      - completed
+
+jobs:
+  publish-slo-report:
+    # Only act on runs that actually executed to completion. A "skipped"
+    # conclusion means the matrix was gated out (no "SLO" label) — nothing to
+    # publish. A "cancelled" conclusion means the run was superseded mid-flight
+    # (e.g. by `cancel-in-progress` when a new run started) — there is no real
+    # report and the label must NOT be stripped, otherwise it gets removed long
+    # before the actual workload finishes. Success/failure are genuine endings.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
+    name: Publish YDB SLO Report
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish YDB SLO Report
+        uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.event.workflow_run.id }}
+
+  remove-slo-label:
+    # Same gating as the report job: only consume the "SLO" label once a run has
+    # genuinely finished (success/failure). Removing it on a "cancelled" run
+    # would strip the label mid-flight when a run is superseded.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
+    name: Remove SLO Label
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove SLO label from PR
+        env:
+          PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          REPO: ${{ github.event.workflow_run.repository.full_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR=$(jq -r '.[0].number' <<<"$PRS")
+          gh pr edit "$PR" --repo "$REPO" --remove-label SLO

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -2,17 +2,25 @@ name: SLO
 
 on:
   pull_request:
-    type: [labeled]
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
 
 jobs:
   ydb-slo-action:
-    if: contains(github.event.pull_request.labels.*.name, 'SLO')
+    # On `labeled` events run only when the `SLO` label itself was just added —
+    # otherwise any unrelated label change would spawn a fresh run that cancels
+    # the in-progress one via `cancel-in-progress`. For the other trigger types
+    # keep gating on the `SLO` label being present.
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'SLO') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'SLO'))
 
     name: Run YDB SLO Tests
     runs-on: large-runner-java-sdk
-
-    permissions:
-      contents: read
 
     strategy:
       fail-fast: false
@@ -133,32 +141,3 @@ jobs:
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
           workload_baseline_image: ydb-app-baseline-${{ matrix.workload.module }}
           workload_baseline_command: --read-rps 1000 --write-rps 100
-
-  publish-slo-report:
-    needs: ydb-slo-action
-
-    name: Publish YDB SLO Report
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
-
-    steps:
-      - name: Publish YDB SLO Report
-        uses: ydb-platform/ydb-slo-action/report@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_run_id: ${{ github.run_id }}
-          github_issue: ${{ github.event.pull_request.number }}
-
-      - name: Remove SLO label from PR
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --remove-label SLO


### PR DESCRIPTION
Brings the SLO workflow in line with ydb-python-sdk to fix the recurring label problems.

### Problems
- `on.pull_request.type: [labeled]` is a **typo** (`type` is not a valid key). GitHub ignores it and falls back to the default types (`opened`/`synchronize`/`reopened`), so **adding the `SLO` label never triggers a run**, and any label change is matched only by the generic `if`.
- Report + label removal live in the same `pull_request` workflow, so for **fork PRs** (read-only token) the `pull-requests: write` steps can't publish the report or remove the label.
- `publish-slo-report` is `needs: ydb-slo-action` with the default success-only gate, so a **partial-matrix failure** (e.g. a flaky workload) silently drops the report and leaves the label stuck.

### Changes
- **Trigger:** `types: [opened, reopened, synchronize, labeled]`, and gate the run on the added label being `SLO` for `labeled` events (present for the others) so unrelated label changes don't spawn a run that cancels the in-progress one via `cancel-in-progress`.
- **Split** report + label removal into `slo-report.yml`, triggered by `workflow_run` of the SLO workflow. It runs in the **base-repo context** (has `pull-requests: write` even for fork PRs) and acts **only on a genuine `success`/`failure`** conclusion — not on `cancelled` (superseded) or `skipped` runs.

The SLO run itself (build + `ydb-slo-action`) is unchanged.