### PR TITLE
SLO: remove SLO label on fork PRs

### DIFF
--- a/.github/workflows/slo-report.yml
+++ b/.github/workflows/slo-report.yml
@@ -47,11 +47,56 @@ jobs:
       pull-requests: write
     steps:
       - name: Remove SLO label from PR
-        env:
-          PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
-          REPO: ${{ github.event.workflow_run.repository.full_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          PR=$(jq -r '.[0].number' <<<"$PRS")
-          gh pr edit "$PR" --repo "$REPO" --remove-label SLO
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflowRun = context.payload.workflow_run;
+            let pullRequestNumbers = [];
+
+            // Same-repo PRs are listed directly in the workflow_run payload.
+            // For fork PRs `pull_requests` is always empty, so resolve the PR
+            // from the run's head branch + fork owner and disambiguate by the
+            // head SHA. Without this the label is never removed on fork PRs.
+            if (workflowRun.pull_requests?.length > 0) {
+              pullRequestNumbers = workflowRun.pull_requests.map((pr) => pr.number);
+            } else if (workflowRun.head_branch && workflowRun.head_repository?.owner?.login) {
+              const head = `${workflowRun.head_repository.owner.login}:${workflowRun.head_branch}`;
+              const { data: pulls } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head,
+                state: 'all',
+                per_page: 100,
+              });
+
+              const matched = workflowRun.head_sha
+                ? pulls.filter((pr) => pr.head.sha === workflowRun.head_sha)
+                : pulls;
+              pullRequestNumbers = (matched.length > 0 ? matched : pulls).map((pr) => pr.number);
+
+              if (pullRequestNumbers.length === 0) {
+                console.log(`No pull requests found for head ${head}`);
+              } else {
+                console.log(`Resolved pull request(s) from head ${head}: #${pullRequestNumbers.join(', #')}`);
+              }
+            } else {
+              console.log('No pull requests associated with this workflow run and unable to resolve head');
+            }
+
+            for (const number of pullRequestNumbers) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  name: 'SLO',
+                });
+                console.log(`Removed SLO label from PR #${number}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`SLO label not found on PR #${number}, skipping`);
+                } else {
+                  throw error;
+                }
+              }
+            }


### PR DESCRIPTION
## Problem

The `Remove SLO Label` job in `slo-report.yml` never removes the label on PRs opened from **forks**.

`github.event.workflow_run.pull_requests` is empty for fork-triggered runs, so `jq -r '.[0].number'` resolves to `null` and the step fails:

```
env:
  PRS: []
no pull requests found for branch "null"
##[error]Process completed with exit code 1.
```

See a failing run on the test PR #676. The same scenario works in ydb-go-sdk (see ydb-platform/ydb-go-sdk#2226), which resolves the PR from the run head instead.

## Fix

Replace the `gh pr edit` shell step with an `actions/github-script` step that:

- uses `workflow_run.pull_requests` for same-repo PRs, and
- falls back to resolving the PR from `head_repository.owner.login:head_branch` (disambiguated by `head_sha`) for fork PRs,
- removes the `SLO` label via the issues API, tolerating a 404 if it is already gone.

Gating is unchanged (only `success`/`failure` runs consume the label; `cancelled`/`skipped` are left alone).