### PR TITLE
Add Codecov coverage status gates

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto       # do not drop below the current level...
+        threshold: 1%      # ...by more than 1%
+    patch:
+      default:
+        target: 80%        # new/changed code in the PR diff must be >= 80% covered
+
 # Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
 # so native-SDK coverage is queryable identically via the Codecov API
 # (?component_id=native-sdk), regardless of how each repo tags its uploads.


### PR DESCRIPTION
Adds a `coverage.status` block to `codecov.yml` so Codecov posts blocking PR checks: the `project` status fails when overall coverage drops by more than 1% versus the base branch (`target: auto`, `threshold: 1%`), and the `patch` status requires the PR diff to be at least 80% covered.

Mirrors the gates already used in ydb-python-sdk, keeping coverage enforcement uniform across the native SDKs. Additive — the existing `ignore`/`component_management` config is untouched.