### PR TITLE
Fixing nanosecond/millisecond mix-up in transport discovery

### DIFF
--- a/core/src/main/java/tech/ydb/core/impl/YdbTransportImpl.java
+++ b/core/src/main/java/tech/ydb/core/impl/YdbTransportImpl.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
@@ -135,11 +136,14 @@ public class YdbTransportImpl extends BaseGrpcTransport {
     protected GrpcChannel getChannel(GrpcRequestSettings settings) {
         EndpointRecord endpoint = endpointPool.getEndpoint(channelPool.getReadyEndpoints(), settings);
         if (endpoint == null) {
-            long timeout = -1;
+            // negative value tells waitReady to use the default discovery timeout
+            long timeoutMs = -1;
             if (settings.getDeadlineAfter() != 0) {
-                timeout = settings.getDeadlineAfter() - System.nanoTime();
+                long leftNanos = settings.getDeadlineAfter() - System.nanoTime();
+                // an already expired deadline must not fall back to the default timeout
+                timeoutMs = Math.max(TimeUnit.NANOSECONDS.toMillis(leftNanos), 1);
             }
-            discovery.waitReady(timeout);
+            discovery.waitReady(timeoutMs);
             endpoint = endpointPool.getEndpoint(Collections.emptySet(), settings);
         }
         return channelPool.getChannel(endpoint);

--- a/core/src/test/java/tech/ydb/core/impl/YdbTransportImplTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/YdbTransportImplTest.java
@@ -27,6 +27,7 @@ import tech.ydb.core.StatusCode;
 import tech.ydb.core.UnexpectedResultException;
 import tech.ydb.core.grpc.GrpcRequestSettings;
 import tech.ydb.core.grpc.GrpcTransport;
+import tech.ydb.core.grpc.GrpcTransportBuilder;
 import tech.ydb.core.grpc.YdbHeaders;
 import tech.ydb.core.impl.pool.EndpointRecord;
 import tech.ydb.core.impl.pool.ManagedChannelFactory;
@@ -181,6 +182,41 @@ public class YdbTransportImplTest {
         Assert.assertEquals("i am node", f2.join().getValue().getUser());
 
         Assert.assertTrue(isReady.isDone());
+    }
+
+    @Test(timeout = 30_000)
+    public void requestDeadlineLimitsWaitingForDiscovery() {
+        Mockito.when(discoveryChannel.newCall(Mockito.eq(DiscoveryServiceGrpc.getListEndpointsMethod()), Mockito.any()))
+                .thenReturn(MockedCall.neverAnswer(testScheduler));
+
+        // deliberately much longer than the deadline of the request below
+        Duration discoveryTimeout = Duration.ofMinutes(10);
+
+        try (GrpcTransport transport = GrpcTransport.forConnectionString("grpc://mocked:2136/local")
+                .withInitMode(GrpcTransportBuilder.InitMode.ASYNC)
+                .withDiscoveryTimeout(discoveryTimeout)
+                .withChannelFactoryBuilder(builder -> channelFactory)
+                .build()
+        ) {
+
+            GrpcRequestSettings settings = GrpcRequestSettings.newBuilder()
+                    .withDeadline(Duration.ofMillis(200))
+                    .build();
+
+            long startedAt = System.nanoTime();
+            Result<DiscoveryProtos.WhoAmIResponse> result = transport
+                    .unaryCall(
+                            DiscoveryServiceGrpc.getWhoAmIMethod(),
+                            settings,
+                            DiscoveryProtos.WhoAmIRequest.newBuilder().build()
+                    )
+                    .join();
+            Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+            Assert.assertFalse(result.isSuccess());
+            // the call must give up near its own deadline instead of waiting for the discovery timeout
+            Assert.assertTrue("discovery waiting took " + elapsed, elapsed.compareTo(discoveryTimeout) < 0);
+        }
     }
 
     @Test


### PR DESCRIPTION
`YdbTransportImpl.getChannel` computed the time left until the request deadline in nanoseconds (`deadlineAfter` is a `System.nanoTime()` value) and passed it to `YdbDiscovery.waitReady(long millis)`, which awaits on a `Condition` with `MILLISECONDS`. A 5 second deadline therefore became a wait of roughly 57 days, so any request issued before the endpoint pool was populated blocked indefinitely instead of failing at its own deadline.