### PR TITLE
Fixing EndpointPool concurrency issues

### DIFF
--- a/core/src/main/java/tech/ydb/core/impl/pool/EndpointPool.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/EndpointPool.java
@@ -42,7 +42,8 @@ public final class EndpointPool {
     private Map<Integer, PriorityEndpoint> recordsByNodeId = new HashMap<>();
     private Map<String, PriorityEndpoint> recordsByEndpoint = new HashMap<>();
 
-    private boolean needToRunDiscovery = false;
+    // read by the discovery scheduler thread without the lock
+    private volatile boolean needToRunDiscovery = false;
     // Number of endpoints with best load factor (priority)
     private int bestEndpointsCount = -1;
 
@@ -163,18 +164,30 @@ public final class EndpointPool {
             return;
         }
 
-        PriorityEndpoint knownEndpoint = recordsByEndpoint.get(endpoint.getHostAndPort());
-        if (knownEndpoint == null) {
-            return;
-        }
-
-        if (knownEndpoint.isPessimized()) {
-            logger.trace("Endpoint {} is already pessimized", endpoint);
-            return;
+        // Fast path under the read lock: re-pessimizing an endpoint changes nothing but forces a full
+        // re-sort of the pool
+        recordsLock.readLock().lock();
+        try {
+            PriorityEndpoint knownEndpoint = recordsByEndpoint.get(endpoint.getHostAndPort());
+            if (knownEndpoint == null) {
+                return;
+            }
+            if (knownEndpoint.isPessimized()) {
+                logger.trace("Endpoint {} is already pessimized", endpoint);
+                return;
+            }
+        } finally {
+            recordsLock.readLock().unlock();
         }
 
         recordsLock.writeLock().lock();
         try {
+            // the pool state may have been replaced by setNewState between the two locks
+            PriorityEndpoint knownEndpoint = recordsByEndpoint.get(endpoint.getHostAndPort());
+            if (knownEndpoint == null || knownEndpoint.isPessimized() || records.isEmpty()) {
+                return;
+            }
+
             knownEndpoint.pessimize();
 
             records.sort(PriorityEndpoint.COMPARATOR);


### PR DESCRIPTION
`pessimizeEndpoint` looked up `recordsByEndpoint` and tested `knownEndpoint.isPessimized()` before taking any lock. Both the map reference and the priority field it reads are non-volatile and are replaced or written under the write lock by `setNewState` and `pessimize`, so those reads had no happens-before edge with the writers. Two threads failing on the same endpoint could each miss the other's update and redo the full re-sort and rescan of the pool, and a lookup against a stale map could pessimize an entry that is no longer part of the current state.

`needToRunDiscovery` is written under the write lock but read by the discovery scheduler thread with no lock at all, so a pessimization-driven discovery could go unnoticed indefinitely.