### PR TITLE
Including nested issues in Issue equality

### DIFF
--- a/core/src/main/java/tech/ydb/core/Issue.java
+++ b/core/src/main/java/tech/ydb/core/Issue.java
@@ -1,6 +1,7 @@
 package tech.ydb.core;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -146,7 +147,8 @@ public class Issue implements Serializable {
                 && Objects.equals(position, issue.position)
                 && Objects.equals(endPosition, issue.endPosition)
                 && Objects.equals(message, issue.message)
-                && severity == issue.severity;
+                && severity == issue.severity
+                && Arrays.equals(issues, issue.issues);
     }
 
     @Override
@@ -156,6 +158,7 @@ public class Issue implements Serializable {
         result = 31 * result + code;
         result = 31 * result + message.hashCode();
         result = 31 * result + severity.hashCode();
+        result = 31 * result + Arrays.hashCode(issues);
         return result;
     }
 

--- a/core/src/test/java/tech/ydb/core/IssueTest.java
+++ b/core/src/test/java/tech/ydb/core/IssueTest.java
@@ -1,8 +1,9 @@
 package tech.ydb.core;
 
-import tech.ydb.core.Issue.Position;
 import org.junit.Assert;
 import org.junit.Test;
+
+import tech.ydb.core.Issue.Position;
 
 
 /**
@@ -36,5 +37,30 @@ public class IssueTest {
             "  #3 message (S_WARNING)\n" +
             "  11:22: #4 message (S_WARNING)\n" +
             "  11:22 at file.cpp: #5 message (S_WARNING)", x.toString());
+    }
+
+    @Test
+    public void testEquals() {
+        Issue nested1 = Issue.of(1, "nested 1", Issue.Severity.WARNING);
+        Issue nested2 = Issue.of(2, "nested 2", Issue.Severity.WARNING);
+
+        Issue plain = Issue.of(7, "cause", Issue.Severity.FATAL);
+        Issue samePlain = Issue.of(7, "cause", Issue.Severity.FATAL);
+
+        Assert.assertEquals(plain, samePlain);
+        Assert.assertEquals(plain.hashCode(), samePlain.hashCode());
+        Assert.assertNotEquals(plain, Issue.of(8, "root cause", Issue.Severity.FATAL));
+        Assert.assertNotEquals(plain, null);
+
+        Issue withNested = Issue.of(Position.EMPTY, Position.EMPTY, 7, "cause", Issue.Severity.FATAL, nested1);
+        Issue withSameNested = Issue.of(Position.EMPTY, Position.EMPTY, 7, "cause", Issue.Severity.FATAL, nested1);
+        Issue withOtherNested = Issue.of(Position.EMPTY, Position.EMPTY, 7, "cause", Issue.Severity.FATAL, nested2);
+
+        Assert.assertEquals(withNested, withSameNested);
+        Assert.assertEquals(withNested.hashCode(), withSameNested.hashCode());
+
+        // issues differing only in their nested issues are different issues
+        Assert.assertNotEquals(withNested, withOtherNested);
+        Assert.assertNotEquals(withNested, plain);
     }
 }

--- a/query/src/test/java/tech/ydb/query/impl/QueryIntegrationTest.java
+++ b/query/src/test/java/tech/ydb/query/impl/QueryIntegrationTest.java
@@ -610,9 +610,13 @@ public class QueryIntegrationTest {
 
                 Assert.assertFalse(result.isSuccess());
                 Assert.assertEquals(StatusCode.PRECONDITION_FAILED, result.getStatus().getCode());
-                Issue issue =  Issue.of(2012,
+                Issue issue = Issue.of(
+                        Issue.Position.EMPTY,
+                        Issue.Position.EMPTY,
+                        2012,
                         "Constraint violated. Table: `" + ydbTransport.getDatabase() + "/" + TEST_TABLE + "`.",
-                        Issue.Severity.ERROR
+                        Issue.Severity.ERROR,
+                        Issue.of(2012, "Conflict with existing key.", Issue.Severity.ERROR)
                 );
                 Assert.assertArrayEquals(new Issue[] { issue }, result.getStatus().getIssues());
 


### PR DESCRIPTION
`Issue.equals` and `Issue.hashCode` ignored the nested issues, so two issues that differed only in their children compared equal.