### PR TITLE
Fixing JWT expiration extraction

### DIFF
--- a/core/src/main/java/tech/ydb/core/auth/JwtUtils.java
+++ b/core/src/main/java/tech/ydb/core/auth/JwtUtils.java
@@ -60,13 +60,14 @@ class JwtUtils {
         }
 
         try {
-            String payload = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+            String payload = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
             JwtClaims claims = GSON.fromJson(payload, JwtClaims.class);
             if (claims != null && claims.getExpiredAt() != null) {
                 return Instant.ofEpochSecond(claims.getExpiredAt());
             }
         } catch (IllegalArgumentException | JsonSyntaxException ex) {
-            logger.error("can't get expire from jwt {}", jwt, ex);
+            // the JWT itself is a credential and must never be logged
+            logger.error("Can't get expire from JWT", ex);
         }
 
         return defaultValue;

--- a/core/src/test/java/tech/ydb/core/auth/JwtBuilder.java
+++ b/core/src/test/java/tech/ydb/core/auth/JwtBuilder.java
@@ -20,7 +20,8 @@ public class JwtBuilder {
         sb.append("\"iss\":\"").append("MOCK").append("\"");
         sb.append("}");
         
-        String base64 = Base64.getEncoder().encodeToString(sb.toString().getBytes(StandardCharsets.UTF_8));
+        String base64 = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(sb.toString().getBytes(StandardCharsets.UTF_8));
         
         return PREFIX + base64;
     }

--- a/core/src/test/java/tech/ydb/core/auth/JwtUtilsTest.java
+++ b/core/src/test/java/tech/ydb/core/auth/JwtUtilsTest.java
@@ -24,4 +24,21 @@ public class JwtUtilsTest {
         Assert.assertEquals(Instant.ofEpochSecond(1726544488), JwtUtils.extractExpireAt(jwt2, Instant.EPOCH));
         Assert.assertEquals(Instant.ofEpochSecond(1726544488), JwtUtils.extractExpireAt(jwt3, Instant.EPOCH));
     }
+
+    @Test
+    public void parseBase64UrlPayloadTest() {
+        // JWT payloads use the base64url alphabet, so they may contain '-' and '_' instead of '+' and '/'
+        // { "alg": "HS256", "typ": "JWT" }.{ "sub": "a?b>c", "aud": "x?y?z", "exp": 1726544488 }
+        String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                + ".eyJzdWIiOiJhP2I-YyIsImF1ZCI6Ing_eT96IiwiZXhwIjoxNzI2NTQ0NDg4fQ";
+
+        Assert.assertEquals(Instant.ofEpochSecond(1726544488), JwtUtils.extractExpireAt(jwt, Instant.EPOCH));
+    }
+
+    @Test
+    public void unparsablePayloadReturnsDefaultTest() {
+        String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.!not-a-base64-payload!";
+
+        Assert.assertEquals(Instant.EPOCH, JwtUtils.extractExpireAt(jwt, Instant.EPOCH));
+    }
 }


### PR DESCRIPTION
JWT parts are `base64url` encoded (RFC 7515), but `extractExpireAt` used `Base64.getDecoder()`, which rejects `-` and `_` with `IllegalArgumentException`. Any token whose payload happened to contain those characters failed to parse, so the caller fell back to the default value.

Also stop logging the jwt itself on a parse failure - it is a bearer credential and does not belong in the logs.