### PR TITLE
Tolerate endpoints without a location when detecting the local DC

### DIFF
--- a/core/src/main/java/tech/ydb/core/impl/pool/PriorityPicker.java
+++ b/core/src/main/java/tech/ydb/core/impl/pool/PriorityPicker.java
@@ -67,8 +67,12 @@ public class PriorityPicker {
 
     @VisibleForTesting
     static String detectLocalDC(List<EndpointRecord> endpoints, Ticker ticker) {
+        // Endpoints without a known location carry no information about datacenters. They must be
+        // filtered out because groupingBy rejects a null key - the endpoint the transport bootstraps
+        // with has no location until the first discovery completes.
         Map<String, List<EndpointRecord>> dcLocationToNodes = endpoints
                 .stream()
+                .filter(endpoint -> endpoint.getLocation() != null && !endpoint.getLocation().isEmpty())
                 .collect(Collectors.groupingBy(EndpointRecord::getLocation));
 
         if (dcLocationToNodes.size() < 2) {

--- a/core/src/test/java/tech/ydb/core/impl/pool/PriorityPickerTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/pool/PriorityPickerTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import javax.net.ServerSocketFactory;
 
+import com.google.common.base.Ticker;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,6 +55,19 @@ public class PriorityPickerTest {
         Assert.assertEquals(0, ignoreSelfLocation.getEndpointPriority("DC1"));
         Assert.assertEquals(0, ignoreSelfLocation.getEndpointPriority("DC2"));
         Assert.assertEquals(0, ignoreSelfLocation.getEndpointPriority("DC3"));
+    }
+
+    @Test
+    public void detectLocalDCWithoutLocationsTest() {
+        // the endpoint a transport bootstraps with has no location until the first discovery completes
+        List<EndpointRecord> bootstrap = Collections.singletonList(new EndpointRecord("localhost", 2136));
+        PriorityPicker picker = PriorityPicker.from(BalancingSettings.detectLocalDs(), null, bootstrap);
+
+        Assert.assertEquals(0, picker.getEndpointPriority("DC1"));
+        Assert.assertEquals(0, picker.getEndpointPriority(null));
+
+        Assert.assertNull(PriorityPicker.detectLocalDC(bootstrap, Ticker.systemTicker()));
+        Assert.assertNull(PriorityPicker.detectLocalDC(Collections.emptyList(), Ticker.systemTicker()));
     }
 
     @Test


### PR DESCRIPTION
`detectLocalDC` grouped endpoints with `Collectors.groupingBy` on `EndpointRecord::getLocation`, which throws `NullPointerException` for a null key. The endpoint that a transport bootstraps with has no location: it is built by `getDiscoveryEndpoint` from the connection string. So `YdbTransportImpl.start` seeded the pool with that endpoint and blew up before reaching the "fewer than two datacenters" guard, making `BalancingSettings.detectLocalDs` unusable in fallback mode.