### PR TITLE
Preserving the cause when copying a Status

### DIFF
--- a/core/src/main/java/tech/ydb/core/Status.java
+++ b/core/src/main/java/tech/ydb/core/Status.java
@@ -140,14 +140,14 @@ public final class Status implements Serializable {
         if (Arrays.equals(this.issues, newIssues)) {
             return this;
         }
-        return new Status(this.code, this.consumedRu, newIssues, null);
+        return new Status(this.code, this.consumedRu, newIssues, this.cause);
     }
 
     public Status withConsumedRu(Double newConsumedRu) {
         if (Objects.equals(this.consumedRu, newConsumedRu)) {
             return this;
         }
-        return new Status(this.code, newConsumedRu, this.issues, null);
+        return new Status(this.code, newConsumedRu, this.issues, this.cause);
     }
 
     public Status withCause(Throwable cause) {

--- a/core/src/test/java/tech/ydb/core/StatusTest.java
+++ b/core/src/test/java/tech/ydb/core/StatusTest.java
@@ -70,4 +70,18 @@ public class StatusTest {
                 ex2.getMessage());
         Assert.assertEquals(wrong, ex2.getStatus());
     }
+
+    @Test
+    public void keepCauseOnCopy() {
+        Throwable cause = new RuntimeException("transport problem");
+        Issue i1 = Issue.of("issue1", Issue.Severity.ERROR);
+
+        Status origin = Status.of(StatusCode.TRANSPORT_UNAVAILABLE, cause);
+        Assert.assertSame(cause, origin.getCause());
+
+        // adding issues or consumed RU to a status must not lose the exception which caused it
+        Assert.assertSame(cause, origin.withIssues(i1).getCause());
+        Assert.assertSame(cause, origin.withConsumedRu(3d).getCause());
+        Assert.assertSame(cause, origin.withConsumedRu(3d).withIssues(i1).getCause());
+    }
 }


### PR DESCRIPTION
`Status.withIssues` and `Status.withConsumedRu` both built the copy with a `null` cause, so attaching issues or consumed RU to a status silently threw away the exception that produced it. Transport failures carry their cause via `GrpcStatuses.toStatus`, and callers such as `TableClientImpl` and `BaseSession` add issues on top of exactly those statuses, so the original exception was lost before it ever reached the user.