### PR TITLE
Fixing edge-case when ReadPartitionSession could stop reading

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/read/impl/ReadPartitionSession.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/ReadPartitionSession.java
@@ -132,20 +132,26 @@ public abstract class ReadPartitionSession {
     }
 
     public void sendDataToReadersIfNeeded() {
-        if (isStopped) {
-            return;
-        }
+        while (!isStopped) {
+            if (!isReadingNow.compareAndSet(false, true)) {
+                logger.trace("[{}] No need to send data to readers: reading is already being performed", traceID);
 
-        if (isReadingNow.compareAndSet(false, true)) {
+                return;
+            }
+
             List<Batch> batchesToRead = new ArrayList<>();
 
             Batch next = readingQueue.peek();
             if (next == null || !next.isReady()) {
                 isReadingNow.set(false);
-                if (next != null && next.isReady()) {
-                    sendDataToReadersIfNeeded();
+                // The head of the queue may have become ready between the peek() above and the release
+                // of the flag. In that case the notification from the decoder thread hit the failed
+                // compareAndSet and was dropped, so the batch has to be picked up here.
+                Batch pending = readingQueue.peek();
+                if (pending == null || !pending.isReady()) {
+                    return;
                 }
-                return;
+                continue;
             }
             next = readingQueue.poll();
 
@@ -193,10 +199,7 @@ public abstract class ReadPartitionSession {
                 batchesToRead.forEach(Batch::complete);
                 sendDataToReadersIfNeeded();
             });
-        } else {
-            if (logger.isTraceEnabled()) {
-                logger.trace("[{}] No need to send data to readers: reading is already being performed", traceID);
-            }
+            return;
         }
     }
 }

--- a/topic/src/test/java/tech/ydb/topic/read/impl/ReadPartitionSessionTest.java
+++ b/topic/src/test/java/tech/ydb/topic/read/impl/ReadPartitionSessionTest.java
@@ -1,0 +1,102 @@
+package tech.ydb.topic.read.impl;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import tech.ydb.proto.topic.YdbTopic;
+import tech.ydb.topic.description.Codec;
+import tech.ydb.topic.description.CodecRegistry;
+import tech.ydb.topic.read.PartitionSession;
+import tech.ydb.topic.read.events.DataReceivedEvent;
+
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class ReadPartitionSessionTest {
+    /**
+     * A batch queued while {@code sendDataToReadersIfNeeded} holds the reading flag must still be delivered. If the
+     * method releases the flag without re-checking the queue, the notification of the queueing thread is lost, the
+     * batch stays unread forever and its read future never completes - which stops the read session from ever
+     * requesting more data.
+     */
+    @Test(timeout = 30_000)
+    public void batchQueuedWhileReadingFlagIsHeldIsNotLost() throws Exception {
+        ReadSession session = mock(ReadSession.class);
+        Mockito.when(session.getMaxBatchSize()).thenReturn(0);
+        Mockito.when(session.getMessageDecoder())
+                .thenReturn(new MessageDecoder(1024, Runnable::run, new CodecRegistry()));
+
+        PartitionSession partition = new PartitionSession(1, 1, "/topic");
+        List<Long> delivered = Collections.synchronizedList(new ArrayList<>());
+
+        ReadPartitionSession reader = new ReadPartitionSession("test", session, partition, 0) {
+            @Override
+            CompletableFuture<Void> handleDataReceivedEvent(DataReceivedEvent event) {
+                event.getMessages().forEach(message -> delivered.add(message.getOffset()));
+                return completedFuture(null);
+            }
+        };
+
+        injectQueue(reader, new EmptyOnceQueue());
+
+        CompletableFuture<Void> batchRead = reader.addBatches(singletonList(rawProtoBatch(1)));
+
+        batchRead.get(10, TimeUnit.SECONDS);
+        assertEquals(singletonList(1L), delivered);
+    }
+
+    private static YdbTopic.StreamReadMessage.ReadResponse.Batch rawProtoBatch(long offset) {
+        return YdbTopic.StreamReadMessage.ReadResponse.Batch.newBuilder()
+                // RAW batches need no decoding, so they are ready as soon as they are queued
+                .setCodec(Codec.RAW)
+                .setProducerId("producer")
+                .addMessageData(YdbTopic.StreamReadMessage.ReadResponse.MessageData.newBuilder()
+                        .setOffset(offset)
+                        .setSeqNo(offset)
+                        .setData(ByteString.copyFromUtf8("data"))
+                        .build()
+                )
+                .build();
+    }
+
+    private static void injectQueue(ReadPartitionSession session, Queue<Batch> queue) throws Exception {
+        Field field = ReadPartitionSession.class.getDeclaredField("readingQueue");
+        field.setAccessible(true);
+        field.set(session, queue);
+    }
+
+    /**
+     * Reading queue that reports itself as empty exactly once.
+     *
+     * <p>It reproduces the interleaving where {@code sendDataToReadersIfNeeded} looks at an empty queue while the gRPC
+     * thread is adding an already decoded batch: the batch is offered and the notification of the gRPC thread is
+     * swallowed by the losing {@code compareAndSet}, all before the reading flag is released.
+     */
+    private static class EmptyOnceQueue extends ConcurrentLinkedQueue<Batch> {
+        private static final long serialVersionUID = 1L;
+
+        private final AtomicBoolean reportEmpty = new AtomicBoolean(true);
+
+        @Override
+        public Batch peek() {
+            if (reportEmpty.getAndSet(false)) {
+                return null;
+            }
+
+            return super.peek();
+        }
+    }
+}


### PR DESCRIPTION
`ReadPartitionSession.sendDataToReadersIfNeeded` takes the `isReadingNow` flag, peeks the queue and, when nothing is deliverable, releases the flag again. The existing re-check only covered the case of a batch that was already queued and became ready in the meantime; when the queue looked empty at `peek()` time the method returned without looking again.

That leaves a lost wakeup. While the flag is held, the gRPC thread can offer an already decoded (`RAW`) batch in `addBatches` and call `sendDataToReadersIfNeeded`, whose `compareAndSet` fails and is silently dropped. The batch is then never delivered, its read future never completes, the `allOf` in `ReadSession.onReadResponse` never fires and the session stops sending `ReadRequests` - the reader stalls forever.

Re-read the head of the queue after releasing the flag instead of re-testing the batch captured before it, and turn the retry into a loop so a burst of these hand-offs cannot nest recursively.