### PR TITLE
Fixing race condition between start() and close() in TopicRetryableStream

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/impl/TopicRetryableStream.java
+++ b/topic/src/main/java/tech/ydb/topic/impl/TopicRetryableStream.java
@@ -62,6 +62,14 @@ public abstract class TopicRetryableStream<R extends Message, W extends Message>
                 onStreamStop(wrapped, retryConfig.getThrowableRetryPolicy(th));
             }
         });
+
+        // close() may have run between the isClosed check above and the publication of this stream. In
+        // that case it found an empty slot, reported that there was nothing to close, and this stream
+        // would stay open forever.
+        if (isClosed && realStream.compareAndSet(stream, null)) {
+            logger.warn("[{}] stream was started concurrently with close, closing it", debugId);
+            stream.close();
+        }
     }
 
     protected void resetRetries() {

--- a/topic/src/test/java/tech/ydb/topic/impl/TopicRetryableStreamTest.java
+++ b/topic/src/test/java/tech/ydb/topic/impl/TopicRetryableStreamTest.java
@@ -22,6 +22,8 @@ import tech.ydb.core.grpc.GrpcReadWriteStream;
 import tech.ydb.topic.utils.HideLoggers;
 import tech.ydb.topic.utils.HideLoggersRule;
 
+import static java.util.Collections.singletonList;
+
 public class TopicRetryableStreamTest {
     private static final Logger logger = LoggerFactory.getLogger(TopicRetryableStreamTest.class);
     private static final Empty EMPTY = Empty.getDefaultInstance();
@@ -163,6 +165,33 @@ public class TopicRetryableStreamTest {
         TestStream retryable = new TestStream(Arrays.asList(), RetryConfig.noRetries(), mockScheduler());
         Assert.assertFalse(retryable.close());
         retryable.start(); // nothing
+    }
+
+    @Test
+    public void closeWhileStartingTest() {
+        StreamHandle streamHandle = new StreamHandle();
+        List<Boolean> closeResults = new ArrayList<>();
+
+        // createNewStream runs exactly in the window between the isClosed check of start() and the
+        // publication of the new stream, so closing from there reproduces the interleaving where
+        // close() finds no stream to close while start() is about to open one
+        TestStream retryable = new TestStream(singletonList(streamHandle), RetryConfig.noRetries(), mockScheduler()) {
+            @Override
+            protected TopicStream<Empty, Empty> createNewStream(String debugId) {
+                TopicStream<Empty, Empty> created = super.createNewStream(debugId);
+                closeResults.add(close());
+                return created;
+            }
+        };
+
+        retryable.start();
+
+        Assert.assertEquals(singletonList(Boolean.FALSE), closeResults);
+        // the stream must not be left running after the retrier was closed
+        Mockito.verify(streamHandle.grpc).close();
+
+        streamHandle.complete(Status.SUCCESS);
+        Assert.assertEquals(Arrays.asList(Status.SUCCESS), retryable.closeStatuses);
     }
 
     @Test


### PR DESCRIPTION
`start()` checked `isClosed` before creating the stream and only published it afterwards. When `close()` ran in between it found an empty `realStream` slot, returned `false` - which `WriterImpl` reads as "the stream will never call onClose", so it finishes the shutdown - and `start()` then went on to open a stream that nothing would ever close. It stayed connected until the server gave up on it.

Re-check `isClosed` once the stream is published and started, and close it if the slot is still ours. The check has to come after `start()` because closing a stream that was never started would half-close a gRPC call that has not begun.