### PR TITLE
Aligning `Error.mapResultFuture`behavior with other implementations of `Result.mapResultFuture`

### DIFF
--- a/core/src/main/java/tech/ydb/core/Result.java
+++ b/core/src/main/java/tech/ydb/core/Result.java
@@ -374,10 +374,9 @@ public interface Result<T> {
 
         @Nonnull
         @Override
+        @SuppressWarnings("unchecked")
         public <U> CompletableFuture<Result<U>> mapResultFuture(Function<V, CompletableFuture<Result<U>>> mapper) {
-            CompletableFuture<Result<U>> future = new CompletableFuture<>();
-            future.completeExceptionally(status.getCause());
-            return future;
+            return CompletableFuture.completedFuture((Error<U>) this);
         }
 
         @Nonnull

--- a/core/src/test/java/tech/ydb/core/ResultTest.java
+++ b/core/src/test/java/tech/ydb/core/ResultTest.java
@@ -1,8 +1,11 @@
 package tech.ydb.core;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
  * @author Sergey Polovko
@@ -215,6 +218,35 @@ public class ResultTest {
 
         Assert.assertSame(Issue.EMPTY_ARRAY, r.getStatus().getIssues());
         Assert.assertEquals(expectedValue, r.getValue());
+    }
+
+    @Test
+    public void errorMapResultFutureKeepsFailedResult() {
+        Throwable cause = new RuntimeException("Some exception");
+        Result<String> error = Result.error("Error message", cause);
+
+        CompletableFuture<Result<String>> mapped = error.mapResultFuture(
+                __ -> completedFuture(Result.success("Must not be called"))
+        );
+
+        // failures are reported as a failed result, exactly like Fail and Unexpected do
+        Assert.assertTrue(mapped.isDone());
+        Assert.assertFalse(mapped.isCompletedExceptionally());
+        Assert.assertEquals(error, mapped.join());
+        Assert.assertEquals(StatusCode.CLIENT_INTERNAL_ERROR, mapped.join().getStatus().getCode());
+        Assert.assertEquals(cause, mapped.join().getStatus().getCause());
+    }
+
+    @Test
+    public void errorWithoutCauseMapResultFuture() {
+        Result<Void> error = Result.error("Error message", null);
+
+        CompletableFuture<Result<String>> mapped = error.mapResultFuture(
+                __ -> completedFuture(Result.success("must not be called"))
+        );
+
+        Assert.assertFalse(mapped.isCompletedExceptionally());
+        Assert.assertEquals(StatusCode.CLIENT_INTERNAL_ERROR, mapped.join().getStatus().getCode());
     }
 
     private static <T> void assertFail(Result<?> r, StatusCode code, Throwable cause) {


### PR DESCRIPTION
`Error.mapResultFuture` was the only `Result` implementation that completed the returned future exceptionally: `Fail`, `Unexpected` and even `Error.mapStatusFuture` all hand back a completed future carrying the failure. That made the outcome of `Result.compose(...)` depend on which flavour of failure it was chaining, and it threw
`NullPointerException` outright for a result built with `Result.error(message, null)`, because `CompletableFuture` rejects a `null` exception.