### PR TITLE
Fixing NullPointerException on valueless query parameters in URITools

### DIFF
--- a/core/src/main/java/tech/ydb/core/utils/URITools.java
+++ b/core/src/main/java/tech/ydb/core/utils/URITools.java
@@ -34,6 +34,10 @@ public class URITools {
     }
 
     private static String decode(String url) {
+        // a parameter without a value, like "?flag" or "?database=", has no string to decode
+        if (url == null) {
+            return null;
+        }
         try {
             return URLDecoder.decode(url, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException ex) {

--- a/core/src/test/java/tech/ydb/core/utils/URIToolsTest.java
+++ b/core/src/test/java/tech/ydb/core/utils/URIToolsTest.java
@@ -1,0 +1,52 @@
+package tech.ydb.core.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class URIToolsTest {
+    @Test
+    public void emptyQueryTest() throws URISyntaxException {
+        assertTrue(URITools.splitQuery(new URI("grpc://localhost:2136/local")).isEmpty());
+        assertTrue(URITools.splitQuery(new URI("grpc://localhost:2136/local?")).isEmpty());
+    }
+
+    @Test
+    public void multipleValuesTest() throws URISyntaxException {
+        Map<String, List<String>> params = URITools.splitQuery(
+                new URI("grpc://localhost:2136/?database=/local&node_id=1&node_id=2")
+        );
+
+        assertEquals(Collections.singletonList("/local"), params.get("database"));
+        assertEquals(Arrays.asList("1", "2"), params.get("node_id"));
+    }
+
+    @Test
+    public void decodedValuesTest() throws URISyntaxException {
+        Map<String, List<String>> params = URITools.splitQuery(
+                new URI("grpc://localhost:2136/?database=%2Flocal%2Fdb")
+        );
+
+        assertEquals(Collections.singletonList("/local/db"), params.get("database"));
+    }
+
+    @Test
+    public void parameterWithoutValueTest() throws URISyntaxException {
+        Map<String, List<String>> params = URITools.splitQuery(
+                new URI("grpc://localhost:2136/?database=&flag&node_id=1")
+        );
+
+        // a parameter without a value is reported as a null value, not as a failure
+        assertEquals(Collections.singletonList(null), params.get("database"));
+        assertEquals(Collections.singletonList(null), params.get("flag"));
+        assertEquals(Collections.singletonList("1"), params.get("node_id"));
+    }
+}


### PR DESCRIPTION
`URITools.splitQueryParameter` mapped a query parameter with no value to `null`, then passed that `null` to `URLDecoder.decode`, which threw `NullPointerException`. So any connection string of the form `?parameter` or `?parameter=` caused `NullPointerException`.