### PR TITLE
Getting rid of log-and-throw constructions

### DIFF
--- a/core/src/main/java/tech/ydb/core/auth/BackgroundIdentity.java
+++ b/core/src/main/java/tech/ydb/core/auth/BackgroundIdentity.java
@@ -9,16 +9,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  *
  * @author Aleksandr Gorshenin
  */
 public class BackgroundIdentity implements tech.ydb.auth.AuthIdentity {
-    private static final Logger logger = LoggerFactory.getLogger(BackgroundIdentity.class);
-
     public interface Rpc extends AutoCloseable {
         class Token {
             private final String token;
@@ -89,10 +84,8 @@ public class BackgroundIdentity implements tech.ydb.auth.AuthIdentity {
         try {
             return future.get(rpc.getTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (ExecutionException | TimeoutException ex) {
-            logger.error("authentication update problem", ex);
             throw new RuntimeException("authentication update problem", ex);
         } catch (InterruptedException ex) {
-            logger.error("updating of authentication token was interrupted", ex);
             Thread.currentThread().interrupt();
             // returning null here would poison the state reference and break every following getToken()
             throw new RuntimeException("authentication update was interrupted", ex);
@@ -233,4 +226,3 @@ public class BackgroundIdentity implements tech.ydb.auth.AuthIdentity {
         }
     }
 }
-

--- a/core/src/main/java/tech/ydb/core/operation/OperationTray.java
+++ b/core/src/main/java/tech/ydb/core/operation/OperationTray.java
@@ -29,8 +29,7 @@ public class OperationTray {
             return future;
         }
 
-        logger.error("unknown type of {}", operation);
-        throw new IllegalArgumentException("Unknown type of operation");
+        throw new IllegalArgumentException("Unknown type of operation: " + operation);
     }
 
     private static <T> boolean complete(Throwable th, CompletableFuture<T> f, AsyncOperation<T> o, long elapsed) {

--- a/core/src/main/java/tech/ydb/core/ssl/YandexTrustManagersProvider.java
+++ b/core/src/main/java/tech/ydb/core/ssl/YandexTrustManagersProvider.java
@@ -18,12 +18,8 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 import com.google.common.io.ByteStreams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class YandexTrustManagersProvider {
-    private static final Logger logger = LoggerFactory.getLogger(YandexTrustManagerFactory.class);
-
     private static final String CA_STORE = "certificates/YandexAllCAs.pkcs";
     private static final String CA_KEYPHRASE = "certificates/YandexAllCAs.password";
 
@@ -48,7 +44,6 @@ final class YandexTrustManagersProvider {
             trustManagers = allTrustManagers.toArray(new TrustManager[0]);
         } catch (NoSuchAlgorithmException | KeyStoreException | CertificateException | IOException e) {
             String msg = "Can't init yandex root CA setting";
-            logger.debug(msg, e);
             throw new RuntimeException(msg, e);
         }
     }

--- a/topic/src/main/java/tech/ydb/topic/impl/SerialExecutor.java
+++ b/topic/src/main/java/tech/ydb/topic/impl/SerialExecutor.java
@@ -41,7 +41,6 @@ public class SerialExecutor implements Executor, Runnable {
             try {
                 executor.execute(this);
             } catch (RuntimeException ex) {
-                logger.error("SerialExecutor cannot execute task", ex);
                 isExecuted.set(false);
                 throw ex;
             }

--- a/topic/src/main/java/tech/ydb/topic/read/impl/DeferredCommitterImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/DeferredCommitterImpl.java
@@ -3,9 +3,6 @@ package tech.ydb.topic.read.impl;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import tech.ydb.topic.read.DeferredCommitter;
 import tech.ydb.topic.read.Message;
 import tech.ydb.topic.read.MessageCommitter;
@@ -16,13 +13,10 @@ import tech.ydb.topic.read.events.DataReceivedEvent;
  * @author Nikolay Perfilov
  */
 public class DeferredCommitterImpl implements DeferredCommitter {
-    private static final Logger logger = LoggerFactory.getLogger(DeferredCommitterImpl.class);
-
     private final Map<MessageCommitter, DisjointOffsetRangeSet> rangesBySession = new ConcurrentHashMap<>();
 
     private RuntimeException wrapExceptionWithSession(PartitionSession session, RuntimeException ex) {
         String msg = "Error adding new offset range to DeferredCommitter for " + session + ": " + ex.getMessage();
-        logger.error(msg);
         return new RuntimeException(msg, ex);
     }
 

--- a/topic/src/main/java/tech/ydb/topic/write/impl/BufferManager.java
+++ b/topic/src/main/java/tech/ydb/topic/write/impl/BufferManager.java
@@ -4,9 +4,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import tech.ydb.core.Status;
 import tech.ydb.topic.settings.WriterSettings;
 import tech.ydb.topic.write.QueueOverflowException;
@@ -16,9 +13,6 @@ import tech.ydb.topic.write.QueueOverflowException;
  * @author Aleksandr Gorshenin
  */
 public class BufferManager {
-    // use logger from WriterImpl
-    private static final Logger logger = LoggerFactory.getLogger(WriterImpl.class);
-
     private final String debugId;
     private final long bufferMaxSize;
     private final int maxCount;
@@ -88,7 +82,6 @@ public class BufferManager {
         if (!countAvailable.tryAcquire()) {
             String errorMsg = "[" + debugId + "] Rejecting a message due to reaching message queue in-flight limit of "
                     + maxCount;
-            logger.warn(errorMsg);
             throw new QueueOverflowException(errorMsg);
         }
 
@@ -105,7 +98,6 @@ public class BufferManager {
             String errorMsg = "[" + debugId + "] Rejecting a message of " + messageSize +
                     " bytes: not enough space in message queue. Buffer currently has " + count +
                     " messages with " + size + " / " + bufferMaxSize + " bytes available";
-            logger.warn(errorMsg);
             throw new QueueOverflowException(errorMsg);
         }
 
@@ -126,7 +118,6 @@ public class BufferManager {
         if (!countAvailable.tryAcquire(timeout, unit)) {
             String errorMsg = "[" + debugId + "] Rejecting a message due to reaching message queue in-flight limit of "
                     + maxCount;
-            logger.warn(errorMsg);
             throw new TimeoutException(errorMsg);
         }
 
@@ -147,7 +138,6 @@ public class BufferManager {
                 String errorMsg = "[" + debugId + "] Rejecting a message of " + messageSize +
                         " bytes: not enough space in message queue. Buffer currently has " + count +
                         " messages with " + size + " / " + bufferMaxSize + " bytes available";
-                logger.warn(errorMsg);
                 throw new TimeoutException(errorMsg);
             }
         } catch (InterruptedException ex) {


### PR DESCRIPTION
Removes log-and-throw constructions that could cause the same failure to be logged multiple times—typically twice: once in the library and once in the top-level application.