### PR TITLE
Add Topic Reader delivered metric

### DIFF
--- a/topic/src/main/java/tech/ydb/topic/TopicClient.java
+++ b/topic/src/main/java/tech/ydb/topic/TopicClient.java
@@ -8,6 +8,7 @@ import javax.annotation.WillNotClose;
 import tech.ydb.core.Result;
 import tech.ydb.core.Status;
 import tech.ydb.core.grpc.GrpcTransport;
+import tech.ydb.core.metrics.Meter;
 import tech.ydb.topic.description.Codec;
 import tech.ydb.topic.description.ConsumerDescription;
 import tech.ydb.topic.description.TopicDescription;
@@ -200,6 +201,14 @@ public interface TopicClient extends AutoCloseable {
          * @return settings builder
          */
         Builder setCompressionPoolThreadCount(Integer compressionPoolThreadCount);
+
+        /**
+         * Enable client metrics using the supplied meter.
+         *
+         * @param meter meter used to create Topic client instruments
+         * @return settings builder
+         */
+        Builder withMeter(Meter meter);
 
         /**
          * Register a custom codec used to compress and decompress topic messages.

--- a/topic/src/main/java/tech/ydb/topic/impl/TopicClientBuilderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/impl/TopicClientBuilderImpl.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import tech.ydb.core.metrics.Meter;
 import tech.ydb.topic.TopicClient;
 import tech.ydb.topic.TopicRpc;
 import tech.ydb.topic.description.Codec;
@@ -18,6 +19,7 @@ public class TopicClientBuilderImpl implements TopicClient.Builder {
     protected final List<Codec> codecs = new ArrayList<>(StandardCodecs.getAvailableCodecs());
     protected Integer compressionExecutorThreadCount;
     protected Executor compressionExecutor;
+    protected Meter meter = Meter.NOOP;
 
     public TopicClientBuilderImpl(TopicRpc topicRpc) {
         this.topicRpc = topicRpc;
@@ -32,6 +34,15 @@ public class TopicClientBuilderImpl implements TopicClient.Builder {
     @Override
     public TopicClientBuilderImpl setCompressionExecutor(Executor compressionExecutor) {
         this.compressionExecutor = compressionExecutor;
+        return this;
+    }
+
+    @Override
+    public TopicClientBuilderImpl withMeter(Meter meter) {
+        if (meter == null) {
+            throw new IllegalArgumentException("Meter must be not null");
+        }
+        this.meter = meter;
         return this;
     }
 

--- a/topic/src/main/java/tech/ydb/topic/impl/TopicClientImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/impl/TopicClientImpl.java
@@ -16,6 +16,8 @@ import org.slf4j.LoggerFactory;
 import tech.ydb.core.Result;
 import tech.ydb.core.Status;
 import tech.ydb.core.grpc.GrpcRequestSettings;
+import tech.ydb.core.impl.Observability;
+import tech.ydb.core.metrics.Meter;
 import tech.ydb.core.operation.Operation;
 import tech.ydb.core.utils.ProtobufUtils;
 import tech.ydb.proto.topic.YdbTopic;
@@ -66,10 +68,13 @@ public class TopicClientImpl implements TopicClient {
     private final Executor compressionExecutor;
     private final ExecutorService defaultCompressionExecutorService;
     private final CodecRegistry codecRegistry;
+    private final Meter meter;
 
     TopicClientImpl(TopicClientBuilderImpl builder) {
         this.topicRpc = builder.topicRpc;
         this.codecRegistry = new CodecRegistry(builder.codecs);
+        this.meter = builder.meter;
+        Observability.reportMetricsUsage(meter);
         if (builder.compressionExecutor != null) {
             this.defaultCompressionExecutorService = null;
             this.compressionExecutor = builder.compressionExecutor;
@@ -372,12 +377,12 @@ public class TopicClientImpl implements TopicClient {
 
     @Override
     public SyncReader createSyncReader(ReaderSettings settings) {
-        return new SyncReaderImpl(topicRpc, settings, codecRegistry);
+        return new SyncReaderImpl(topicRpc, settings, codecRegistry, meter);
     }
 
     @Override
     public AsyncReader createAsyncReader(ReaderSettings settings, ReadEventHandlersSettings handlersSettings) {
-        return new AsyncReaderImpl(topicRpc, settings, handlersSettings, codecRegistry);
+        return new AsyncReaderImpl(topicRpc, settings, handlersSettings, codecRegistry, meter);
     }
 
     @Override

--- a/topic/src/main/java/tech/ydb/topic/read/impl/AsyncReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/AsyncReaderImpl.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import tech.ydb.common.transaction.YdbTransaction;
 import tech.ydb.core.Status;
+import tech.ydb.core.metrics.Meter;
 import tech.ydb.topic.TopicRpc;
 import tech.ydb.topic.description.CodecRegistry;
 import tech.ydb.topic.impl.SerialExecutor;
@@ -48,7 +49,15 @@ public class AsyncReaderImpl extends ReaderImpl implements AsyncReader {
                            ReaderSettings settings,
                            ReadEventHandlersSettings handlersSettings,
                            @Nonnull CodecRegistry codecRegistry) {
-        super(topicRpc, settings, codecRegistry);
+        this(topicRpc, settings, handlersSettings, codecRegistry, Meter.NOOP);
+    }
+
+    public AsyncReaderImpl(TopicRpc topicRpc,
+                           ReaderSettings settings,
+                           ReadEventHandlersSettings handlersSettings,
+                           @Nonnull CodecRegistry codecRegistry,
+                           Meter meter) {
+        super(topicRpc, settings, codecRegistry, meter);
         this.eventHandler = handlersSettings.getEventHandler();
 
         if (handlersSettings.getExecutor() != null) {
@@ -100,6 +109,7 @@ public class AsyncReaderImpl extends ReaderImpl implements AsyncReader {
             long offsetEnd = event.getMessages().get(event.getMessages().size() - 1).getOffset();
             logger.debug("{} DataReceivedEvent callback with {} message(s) (offsets {}-{}) is about "
                     + "to be called...", session, messagesCount, offsetStart, offsetEnd);
+            getMetrics().reportDelivered(messagesCount, session.getPartition().getPath());
             eventHandler.onMessages(event);
             logger.debug("{} DataReceivedEvent callback with {} message(s) (offsets {}-{}) "
                     + "successfully finished", session, messagesCount, offsetStart, offsetEnd);

--- a/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/ReaderImpl.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import tech.ydb.common.transaction.YdbTransaction;
 import tech.ydb.core.Status;
+import tech.ydb.core.metrics.Meter;
 import tech.ydb.topic.TopicRpc;
 import tech.ydb.topic.description.CodecRegistry;
 import tech.ydb.topic.impl.GrpcStreamRetrier;
@@ -36,12 +37,19 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
     private static final int DEFAULT_DECOMPRESSION_THREAD_COUNT = 4;
     private final ExecutorService defaultDecompressionExecutorService;
     private final ReadSessionFactory sessionFactory;
+    private final ReaderMetrics metrics;
 
     private final CompletableFuture<Void> sessionReady = new CompletableFuture<>();
     private volatile ReadSession session = null;
 
     public ReaderImpl(TopicRpc topicRpc, ReaderSettings settings, @Nonnull CodecRegistry codecRegistry) {
+        this(topicRpc, settings, codecRegistry, Meter.NOOP);
+    }
+
+    public ReaderImpl(TopicRpc topicRpc, ReaderSettings settings, @Nonnull CodecRegistry codecRegistry, Meter meter) {
         super(settings.getLogPrefix(), topicRpc.getScheduler(), settings.getErrorsHandler());
+
+        this.metrics = new ReaderMetrics(meter, settings.getConsumerName(), settings.getReaderName());
 
         Executor decompressionExecutor = settings.getDecompressionExecutor();
         if (decompressionExecutor != null) {
@@ -70,6 +78,10 @@ public abstract class ReaderImpl extends GrpcStreamRetrier {
     protected abstract void handleStartPartitionSessionRequest(StartPartitionSessionEvent event);
     protected abstract void handleStopPartitionSession(StopPartitionSessionEvent event);
     protected abstract void handleClosePartitionSession(PartitionSession partition);
+
+    final ReaderMetrics getMetrics() {
+        return metrics;
+    }
 
     @Override
     protected Logger getLogger() {

--- a/topic/src/main/java/tech/ydb/topic/read/impl/ReaderMetrics.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/ReaderMetrics.java
@@ -1,0 +1,48 @@
+package tech.ydb.topic.read.impl;
+
+import java.util.Arrays;
+
+import tech.ydb.core.metrics.Attr;
+import tech.ydb.core.metrics.LongCounter;
+import tech.ydb.core.metrics.Meter;
+
+/**
+ * Topic reader delivery metrics.
+ */
+final class ReaderMetrics {
+    private static final String MESSAGE_UNIT = "{message}";
+
+    private final LongCounter deliveredMessages;
+    private final Attr[] commonAttributes;
+
+    ReaderMetrics(Meter meter, String consumer, String readerName) {
+        this.deliveredMessages = meter.createCounter(
+                "ydb.topic.reader.delivered.messages",
+                MESSAGE_UNIT,
+                "The number of messages delivered by the SDK to application code.");
+        this.commonAttributes = createCommonAttributes(consumer, readerName);
+    }
+
+    void reportDelivered(long messages, String topic) {
+        record(deliveredMessages, messages, topic);
+    }
+
+    private void record(LongCounter counter, long value, String topic) {
+        if (value > 0) {
+            Attr[] attributes = Arrays.copyOf(commonAttributes, commonAttributes.length + 1);
+            attributes[commonAttributes.length] = Attr.of("topic", topic);
+            counter.add(value, attributes);
+        }
+    }
+
+    private static Attr[] createCommonAttributes(String consumer, String readerName) {
+        boolean hasReaderName = readerName != null && !readerName.isEmpty();
+        if (consumer == null) {
+            return hasReaderName ? new Attr[]{Attr.of("reader.name", readerName)} : new Attr[0];
+        }
+        if (!hasReaderName) {
+            return new Attr[]{Attr.of("consumer", consumer)};
+        }
+        return new Attr[]{Attr.of("consumer", consumer), Attr.of("reader.name", readerName)};
+    }
+}

--- a/topic/src/main/java/tech/ydb/topic/read/impl/SyncReaderImpl.java
+++ b/topic/src/main/java/tech/ydb/topic/read/impl/SyncReaderImpl.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import tech.ydb.core.Status;
+import tech.ydb.core.metrics.Meter;
 import tech.ydb.topic.TopicRpc;
 import tech.ydb.topic.description.CodecRegistry;
 import tech.ydb.topic.description.OffsetsRange;
@@ -46,7 +47,12 @@ public class SyncReaderImpl extends ReaderImpl implements SyncReader {
     private volatile String sessionId = null;
 
     public SyncReaderImpl(TopicRpc topicRpc, ReaderSettings settings, @Nonnull CodecRegistry codecRegistry) {
-        super(topicRpc, settings, codecRegistry);
+        this(topicRpc, settings, codecRegistry, Meter.NOOP);
+    }
+
+    public SyncReaderImpl(TopicRpc topicRpc, ReaderSettings settings, @Nonnull CodecRegistry codecRegistry,
+            Meter meter) {
+        super(topicRpc, settings, codecRegistry, meter);
     }
 
     private static class MessageWrapper {
@@ -157,6 +163,7 @@ public class SyncReaderImpl extends ReaderImpl implements SyncReader {
             }
 
             next.release();
+            getMetrics().reportDelivered(1, result.getPartitionSession().getPath());
             return result;
         }
     }

--- a/topic/src/test/java/tech/ydb/topic/read/impl/ReaderMetricsTest.java
+++ b/topic/src/test/java/tech/ydb/topic/read/impl/ReaderMetricsTest.java
@@ -1,0 +1,71 @@
+package tech.ydb.topic.read.impl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import tech.ydb.core.metrics.LongCounter;
+import tech.ydb.core.metrics.Meter;
+import tech.ydb.topic.TopicClient;
+import tech.ydb.topic.TopicRpc;
+import tech.ydb.topic.description.Codec;
+import tech.ydb.topic.impl.TopicClientImpl;
+import tech.ydb.topic.read.SyncReader;
+import tech.ydb.topic.settings.ReaderSettings;
+import tech.ydb.topic.settings.TopicReadSettings;
+
+public class ReaderMetricsTest {
+    private static final String DELIVERED = "ydb.topic.reader.delivered.messages";
+
+    @Test
+    public void deliveredMessageIncrementsCounter() throws InterruptedException {
+        RecordingMeter meter = new RecordingMeter();
+        ReadStreamMock stream = new ReadStreamMock();
+        TopicRpc rpc = Mockito.mock(TopicRpc.class);
+        Mockito.when(rpc.getScheduler()).thenReturn(Mockito.mock(ScheduledExecutorService.class));
+        Mockito.when(rpc.readSession(Mockito.any(String.class))).thenReturn(stream);
+
+        TopicClient client = TopicClientImpl.newClient(rpc).withMeter(meter).build();
+        SyncReader reader = client.createSyncReader(ReaderSettings.newBuilder()
+                .addTopic(TopicReadSettings.newBuilder().setPath("/topic").build())
+                .setConsumerName("consumer")
+                .build());
+
+        try {
+            reader.init();
+            stream.responseInit("read-session");
+            stream.responseStartPartition("/topic", 42);
+            stream.responseData(25).partition(1, -1)
+                    .batch(Codec.RAW, new byte[] { 1 })
+                    .and().send();
+
+            Assert.assertEquals(0, meter.value(DELIVERED));
+
+            Assert.assertNotNull(reader.receive());
+            Assert.assertEquals(1, meter.value(DELIVERED));
+        } finally {
+            reader.shutdown();
+            client.close();
+        }
+    }
+
+    private static class RecordingMeter implements Meter {
+        private final Map<String, AtomicLong> counters = new ConcurrentHashMap<>();
+
+        @Override
+        public LongCounter createCounter(String name, String unit, String description) {
+            AtomicLong counter = counters.computeIfAbsent(name, key -> new AtomicLong());
+            return (value, attrs) -> counter.addAndGet(value);
+        }
+
+        long value(String name) {
+            AtomicLong counter = counters.get(name);
+            return counter == null ? 0 : counter.get();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add opt-in Topic client metrics through the existing `tech.ydb.core.metrics.Meter` abstraction; the default remains `Meter.NOOP` and metric usage is reported through `Observability`.
- Add the `ydb.topic.reader.delivered.messages` counter with unit `{message}` and attributes `topic` and `consumer`.
- Record delivered messages immediately before the async callback or immediately before a sync receive successfully returns a message.
- Add optional `reader.name` with the exact configured non-empty `ReaderName`. It is omitted for null/empty names; no fallback identifier is generated, so unnamed readers intentionally aggregate by the other attributes.
- Do not change Reader receive, session, or commit behavior.

## Tests

- `./mvnw -pl core,topic -am clean test -DskipITs`
  - Reactor build successful.
  - Core: 154 tests, 0 failures, 0 errors.
  - Topic: 99 tests, 0 failures, 0 errors, 5 integration tests skipped because no local YDB helper was available.
  - Checkstyle: 0 violations.
- `./mvnw -pl topic -am -DskipITs -Dtest=ReaderMetricsTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 1 focused test verifies that one message successfully returned by the sync Reader increments the delivered counter from 0 to 1.
