### PR TITLE
Deprecate Session.executeScanQuery in favor of query service

### DIFF
--- a/query/src/test/java/tech/ydb/query/TableExampleTest.java
+++ b/query/src/test/java/tech/ydb/query/TableExampleTest.java
@@ -307,6 +307,7 @@ public class TableExampleTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void step07_scanQueryWithParams() {
         String query
                 = "DECLARE $seriesId AS Uint64; "

--- a/table/src/main/java/tech/ydb/table/Session.java
+++ b/table/src/main/java/tech/ydb/table/Session.java
@@ -149,9 +149,17 @@ public interface Session extends AutoCloseable {
 
     GrpcReadStream<ReadTablePart> executeReadTable(String tablePath, ReadTableSettings settings);
 
+    /**
+     * @deprecated use QuerySession#createQuery of the query service (ydb-sdk-query) instead
+     */
+    @Deprecated
     GrpcReadStream<ValueProtos.ResultSet> executeScanQueryRaw(String query, Params params,
             ExecuteScanQuerySettings settings);
 
+    /**
+     * @deprecated use QuerySession#createQuery of the query service (ydb-sdk-query) instead
+     */
+    @Deprecated
     default GrpcReadStream<ResultSetReader> executeScanQuery(String query, Params params,
             ExecuteScanQuerySettings settings) {
         GrpcReadStream<ValueProtos.ResultSet> stream = executeScanQueryRaw(query, params, settings);

--- a/table/src/main/java/tech/ydb/table/impl/BaseSession.java
+++ b/table/src/main/java/tech/ydb/table/impl/BaseSession.java
@@ -1330,6 +1330,7 @@ public abstract class BaseSession implements Session {
     }
 
     @Override
+    @Deprecated
     public GrpcReadStream<ValueProtos.ResultSet> executeScanQueryRaw(String query, Params params,
                                                             ExecuteScanQuerySettings settings) {
         YdbTable.ExecuteScanQueryRequest req = YdbTable.ExecuteScanQueryRequest.newBuilder()

--- a/table/src/test/java/tech/ydb/table/SessionStub.java
+++ b/table/src/test/java/tech/ydb/table/SessionStub.java
@@ -158,6 +158,7 @@ public class SessionStub implements Session {
     }
 
     @Override
+    @Deprecated
     public GrpcReadStream<ValueProtos.ResultSet> executeScanQueryRaw(String query, Params params, ExecuteScanQuerySettings settings) {
         throw new UnsupportedOperationException("executeScanQuery not implemented");
     }

--- a/table/src/test/java/tech/ydb/table/integration/BulkUpsertTest.java
+++ b/table/src/test/java/tech/ydb/table/integration/BulkUpsertTest.java
@@ -76,6 +76,7 @@ public class BulkUpsertTest {
                 .join().expectSuccess("bulk upsert problem in table " + tablePath());
     }
 
+    @SuppressWarnings("deprecation")
     private static int readTable(long id1, BiConsumer<Integer, ResultSetReader> validator) {
         AtomicInteger count = new AtomicInteger();
 
@@ -165,6 +166,7 @@ public class BulkUpsertTest {
 
     @Test
     @Ignore("https://github.com/ydb-platform/ydb/issues/36331")
+    @SuppressWarnings("deprecation")
     public void writeApacheArrowEmptyStringToDataShardTest() {
         // Create table
         TableDescription table = TableDescription.newBuilder()

--- a/table/src/test/java/tech/ydb/table/integration/TableClientTest.java
+++ b/table/src/test/java/tech/ydb/table/integration/TableClientTest.java
@@ -125,6 +125,7 @@ public class TableClientTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void sessionExecuteScanQueryTest() {
         ExecuteScanQuerySettings settings = ExecuteScanQuerySettings.newBuilder().build();
 


### PR DESCRIPTION
Marks `Session.executeScanQuery` and `Session.executeScanQueryRaw` as `@Deprecated`, pointing to the query service (`ydb-sdk-query`).

The javadoc references `QuerySession` in plain text rather than `{@link}` because `ydb-sdk-query` depends on `ydb-sdk-table`, not the other way round.

Implementations and the tests that intentionally cover the old API are annotated so the build stays warning-free.