### PR TITLE
Core: treat gRPC ResourceExhausted 'message larger than max' as non-r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.12 ##
+* Core: treat gRPC ResourceExhausted "message larger than max" as non-retryable
+
 ## 2.4.11 ##
 * Table: fixed StackOverflow problem for the immediately released sessions
 

--- a/core/src/main/java/tech/ydb/core/grpc/GrpcStatuses.java
+++ b/core/src/main/java/tech/ydb/core/grpc/GrpcStatuses.java
@@ -26,7 +26,7 @@ public final class GrpcStatuses {
             return Status.SUCCESS;
         }
         Issue message = Issue.of(getMessage(status, endpoint), Issue.Severity.ERROR);
-        StatusCode code = getStatusCode(status.getCode());
+        StatusCode code = getStatusCode(status);
         Throwable cause = status.getCause();
 
         if (cause == null) {
@@ -49,16 +49,29 @@ public final class GrpcStatuses {
         return message;
     }
 
-    private static StatusCode getStatusCode(io.grpc.Status.Code code) {
-        switch (code) {
+    private static StatusCode getStatusCode(io.grpc.Status status) {
+        switch (status.getCode()) {
             case UNAVAILABLE: return StatusCode.TRANSPORT_UNAVAILABLE;
             case UNAUTHENTICATED: return StatusCode.CLIENT_UNAUTHENTICATED;
             case CANCELLED: return StatusCode.CLIENT_CANCELLED;
             case UNIMPLEMENTED: return StatusCode.CLIENT_CALL_UNIMPLEMENTED;
             case DEADLINE_EXCEEDED: return StatusCode.CLIENT_DEADLINE_EXCEEDED;
-            case RESOURCE_EXHAUSTED: return StatusCode.CLIENT_RESOURCE_EXHAUSTED;
+            case RESOURCE_EXHAUSTED:
+                // A message that exceeds the gRPC size limit is a deterministic client-side error:
+                // retrying it with the same payload always fails identically. Map it to a non-retryable
+                // status so the caller fails fast instead of spinning through the retry budget.
+                // Other ResourceExhausted errors (e.g. quota or rate limiting) stay retryable.
+                if (isMessageLargerThanMax(status.getDescription())) {
+                    return StatusCode.BAD_REQUEST;
+                }
+                return StatusCode.CLIENT_RESOURCE_EXHAUSTED;
             default:
                 return StatusCode.CLIENT_GRPC_ERROR;
         }
+    }
+
+    private static boolean isMessageLargerThanMax(String description) {
+        return description != null && (description.contains("trying to send message larger than max")
+                || description.contains("received message larger than max"));
     }
 }

--- a/core/src/test/java/tech/ydb/core/grpc/GrpcStatusesTest.java
+++ b/core/src/test/java/tech/ydb/core/grpc/GrpcStatusesTest.java
@@ -118,6 +118,34 @@ public class GrpcStatusesTest {
     }
 
     @Test
+    public void statusResourceExhaustedMessageTooLargeSend() {
+        Status status = GrpcStatuses.toStatus(
+                io.grpc.Status.RESOURCE_EXHAUSTED.withDescription("trying to send message larger than max"), "test");
+        Issue issue = Issue.of(
+                "gRPC error: (RESOURCE_EXHAUSTED) on test, trying to send message larger than max",
+                Issue.Severity.ERROR);
+        assertEquals(Status.of(StatusCode.BAD_REQUEST).withIssues(issue), status);
+    }
+
+    @Test
+    public void statusResourceExhaustedMessageTooLargeReceive() {
+        Status status = GrpcStatuses.toStatus(
+                io.grpc.Status.RESOURCE_EXHAUSTED.withDescription("received message larger than max"), "test");
+        Issue issue = Issue.of(
+                "gRPC error: (RESOURCE_EXHAUSTED) on test, received message larger than max",
+                Issue.Severity.ERROR);
+        assertEquals(Status.of(StatusCode.BAD_REQUEST).withIssues(issue), status);
+    }
+
+    @Test
+    public void statusResourceExhaustedOtherDescription() {
+        Status status = GrpcStatuses.toStatus(
+                io.grpc.Status.RESOURCE_EXHAUSTED.withDescription("quota exceeded"), "test");
+        Issue issue = Issue.of("gRPC error: (RESOURCE_EXHAUSTED) on test, quota exceeded", Issue.Severity.ERROR);
+        assertEquals(Status.of(StatusCode.CLIENT_RESOURCE_EXHAUSTED).withIssues(issue), status);
+    }
+
+    @Test
     public void statusThrowable() {
         Throwable th = new RuntimeException("Hello");
         Status status = GrpcStatuses.toStatus(io.grpc.Status.RESOURCE_EXHAUSTED.withCause(th), "test");


### PR DESCRIPTION
# Core: treat gRPC ResourceExhausted "message larger than max" as non-retryable

Fixes #621

## Problem
When sending a large payload (e.g. UPSERT with a `$data` parameter exceeding the gRPC message limit),
the driver returns `ResourceExhausted` ("trying to send message larger than max"). This error is
currently classified as retryable, so the SDK retries it with slow backoff up to `maxRetries` times.
Since the payload size does not change between attempts, every retry fails identically — the operation
effectively hangs until timeout or context cancellation, instead of failing fast.

## Root cause
`RESOURCE_EXHAUSTED` is unconditionally mapped to `StatusCode.CLIENT_RESOURCE_EXHAUSTED` in
`GrpcStatuses.getStatusCode()`. That status is in `RETRYABLE_STATUSES` and mapped to slow backoff in
`YdbRetryConfig` and both `SessionRetryContext` implementations, so the retry loop never distinguishes
the deterministic "message too large" case from transient server-side resource exhaustion.

## Fix
In `GrpcStatuses.getStatusCode()`, inspect the gRPC status description when the code is
`RESOURCE_EXHAUSTED` and map the message-size-limit variants to `BAD_REQUEST` (non-retryable),
mirroring the fix already merged in the Go SDK (ydb-platform/ydb-go-sdk#2105):
- "trying to send message larger than max" (client-side send)
- "received message larger than max" (client-side receive)

All other `ResourceExhausted` errors (quota, rate limiting) keep the existing behavior and remain retryable.

## Tests
Added to `GrpcStatusesTest`: send/receive variants map to `BAD_REQUEST`, other descriptions keep
`CLIENT_RESOURCE_EXHAUSTED`. Verified with `./mvnw test` (all modules, BUILD SUCCESS).