### PR TITLE
Core: invoke ready watcher even if discovery fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.12 ##
+* Core: fixed ready watcher invocation on discovery error
+
 ## 2.4.11 ##
 * Table: fixed StackOverflow problem for the immediately released sessions
 

--- a/core/src/main/java/tech/ydb/core/impl/YdbTransportImpl.java
+++ b/core/src/main/java/tech/ydb/core/impl/YdbTransportImpl.java
@@ -83,8 +83,13 @@ public class YdbTransportImpl extends BaseGrpcTransport {
         discovery.start();
         if (readyWatcher != null) {
             scheduler.execute(() -> {
-                discovery.waitReady(-1);
-                readyWatcher.run();
+                try {
+                    discovery.waitReady(-1);
+                } catch (RuntimeException ex) {
+                    logger.warn("Discovery failed during async transport initialization", ex);
+                } finally {
+                    readyWatcher.run();
+                }
             });
         }
     }

--- a/core/src/test/java/tech/ydb/core/impl/YdbTransportImplTest.java
+++ b/core/src/test/java/tech/ydb/core/impl/YdbTransportImplTest.java
@@ -187,6 +187,34 @@ public class YdbTransportImplTest {
     }
 
     @Test
+    public void asyncBuildDiscoveryErrorTest() {
+        MockedScheduler scheduler = new MockedScheduler(MockedClock.create(ZoneId.of("UTC")));
+
+        Mockito.when(discoveryChannel.newCall(Mockito.eq(DiscoveryServiceGrpc.getListEndpointsMethod()), Mockito.any()))
+                .thenReturn(MockedCall.unavailable());
+
+        CompletableFuture<Void> isReady = new CompletableFuture<>();
+
+        @SuppressWarnings("deprecation")
+        GrpcTransport transport = GrpcTransport.forConnectionString("grpc://mocked:2136/local")
+                .withSchedulerFactory(() -> scheduler)
+                .withDiscoveryTimeout(Duration.ofMillis(100))
+                .withChannelFactoryBuilder(builder -> channelFactory)
+                .buildAsync(() -> isReady.complete(null));
+
+        Assert.assertNotNull(transport);
+        Assert.assertFalse(isReady.isDone());
+
+        // Run discovery task and ready-watcher task
+        scheduler.hasTasksCount(2).runNextTask().runNextTask();
+
+        // readyWatcher must be called even if discovery fails
+        Assert.assertTrue(isReady.isDone());
+
+        transport.close();
+    }
+
+    @Test
     @SuppressWarnings("SleepWhileInLoop")
     public void asyncWaitingForReadyTest() throws Exception {
         CountDownLatch discoveryLatch = new CountDownLatch(1);


### PR DESCRIPTION
# Core: invoke ready watcher even if discovery fails

Fixes #294

## Problem

When a transport is created asynchronously via `GrpcTransportBuilder.buildAsync(Runnable readyWatcher)`, the `readyWatcher` callback is never invoked if the initial discovery fails. The caller waits forever and the transport is left in an unusable state without any notification.

## Root cause

`YdbTransportImpl.startAsync(Runnable readyWatcher)` schedules a task that calls `discovery.waitReady(-1)` and then `readyWatcher.run()`:

```java
scheduler.execute(() -> {
    discovery.waitReady(-1);
    readyWatcher.run();
});
```

`YdbDiscovery.waitReady()` throws `IllegalStateException("Discovery failed", ...)` when discovery fails. The exception is swallowed by the executor, so `readyWatcher.run()` is never executed.

## Fix

Wrap `waitReady` in `try/catch/finally` so that `readyWatcher.run()` is always executed, and log the discovery failure with its cause for diagnostics:

```java
scheduler.execute(() -> {
    try {
        discovery.waitReady(-1);
    } catch (RuntimeException ex) {
        logger.warn("Discovery failed during async transport initialization", ex);
    } finally {
        readyWatcher.run();
    }
});
```

The synchronous path (`build()`) is not affected: there the exception is propagated to the caller, which is the correct behavior.

## Tests

Added `asyncBuildDiscoveryErrorTest` in `YdbTransportImplTest`: it stubs the discovery call to fail with `UNAVAILABLE`, builds the transport with `buildAsync`, runs the scheduler tasks and asserts that the ready watcher is invoked. The test fails without this fix (ready watcher is never called) and passes with it.

- `./mvnw -pl core test` — 155 tests, all green
- Checkstyle: 0 violations